### PR TITLE
chore: TypeScript 5.9.3 to 6.0.2 upgrade

### DIFF
--- a/app/globals.css.d.ts
+++ b/app/globals.css.d.ts
@@ -1,0 +1,2 @@
+// Declaration file for CSS side-effect import (required for TypeScript 6.x with allowArbitraryExtensions)
+export {};

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "tailwindcss": "^4.1.18",
     "tailwindcss-animate": "^1.0.7",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.0",
     "vite-tsconfig-paths": "^6.0.3",
     "vitest": "^4.0.18"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,7 +58,7 @@ importers:
         version: 16.0.10(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-intl:
         specifier: ^4.6.1
-        version: 4.6.1(next@16.0.10(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+        version: 4.6.1(next@16.0.10(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(typescript@6.0.2)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -83,7 +83,7 @@ importers:
     devDependencies:
       '@commitlint/cli':
         specifier: ^20.5.0
-        version: 20.5.0(@types/node@25.0.2)(conventional-commits-parser@6.3.0)(typescript@5.9.3)
+        version: 20.5.0(@types/node@25.0.2)(conventional-commits-parser@6.3.0)(typescript@6.0.2)
       '@commitlint/config-conventional':
         specifier: ^20.5.0
         version: 20.5.0
@@ -139,11 +139,11 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.0
+        version: 6.0.2
       vite-tsconfig-paths:
         specifier: ^6.0.3
-        version: 6.0.3(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 6.0.3(typescript@6.0.2)(vite@7.3.1(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@25.0.2)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@27.3.0)(lightningcss@1.30.2)(tsx@4.21.0)
@@ -2615,8 +2615,8 @@ packages:
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -2957,11 +2957,11 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@commitlint/cli@20.5.0(@types/node@25.0.2)(conventional-commits-parser@6.3.0)(typescript@5.9.3)':
+  '@commitlint/cli@20.5.0(@types/node@25.0.2)(conventional-commits-parser@6.3.0)(typescript@6.0.2)':
     dependencies:
       '@commitlint/format': 20.5.0
       '@commitlint/lint': 20.5.0
-      '@commitlint/load': 20.5.0(@types/node@25.0.2)(typescript@5.9.3)
+      '@commitlint/load': 20.5.0(@types/node@25.0.2)(typescript@6.0.2)
       '@commitlint/read': 20.5.0(conventional-commits-parser@6.3.0)
       '@commitlint/types': 20.5.0
       tinyexec: 1.0.2
@@ -3010,14 +3010,14 @@ snapshots:
       '@commitlint/rules': 20.5.0
       '@commitlint/types': 20.5.0
 
-  '@commitlint/load@20.5.0(@types/node@25.0.2)(typescript@5.9.3)':
+  '@commitlint/load@20.5.0(@types/node@25.0.2)(typescript@6.0.2)':
     dependencies:
       '@commitlint/config-validator': 20.5.0
       '@commitlint/execute-rule': 20.0.0
       '@commitlint/resolve-extends': 20.5.0
       '@commitlint/types': 20.5.0
-      cosmiconfig: 9.0.1(typescript@5.9.3)
-      cosmiconfig-typescript-loader: 6.2.0(@types/node@25.0.2)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3)
+      cosmiconfig: 9.0.1(typescript@6.0.2)
+      cosmiconfig-typescript-loader: 6.2.0(@types/node@25.0.2)(cosmiconfig@9.0.1(typescript@6.0.2))(typescript@6.0.2)
       is-plain-obj: 4.1.0
       lodash.mergewith: 4.6.2
       picocolors: 1.1.1
@@ -4269,21 +4269,21 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cosmiconfig-typescript-loader@6.2.0(@types/node@25.0.2)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3):
+  cosmiconfig-typescript-loader@6.2.0(@types/node@25.0.2)(cosmiconfig@9.0.1(typescript@6.0.2))(typescript@6.0.2):
     dependencies:
       '@types/node': 25.0.2
-      cosmiconfig: 9.0.1(typescript@5.9.3)
+      cosmiconfig: 9.0.1(typescript@6.0.2)
       jiti: 2.6.1
-      typescript: 5.9.3
+      typescript: 6.0.2
 
-  cosmiconfig@9.0.1(typescript@5.9.3):
+  cosmiconfig@9.0.1(typescript@6.0.2):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
       js-yaml: 4.1.1
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
 
   css-tree@3.1.0:
     dependencies:
@@ -4702,7 +4702,7 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.6.1: {}
 
-  next-intl@4.6.1(next@16.0.10(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
+  next-intl@4.6.1(next@16.0.10(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(typescript@6.0.2):
     dependencies:
       '@formatjs/intl-localematcher': 0.5.10
       '@parcel/watcher': 2.5.1
@@ -4714,7 +4714,7 @@ snapshots:
       react: 19.2.3
       use-intl: 4.6.1(react@19.2.3)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -5011,9 +5011,9 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  tsconfck@3.1.6(typescript@5.9.3):
+  tsconfck@3.1.6(typescript@6.0.2):
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
 
   tslib@2.8.1: {}
 
@@ -5026,7 +5026,7 @@ snapshots:
 
   tw-animate-css@1.4.0: {}
 
-  typescript@5.9.3: {}
+  typescript@6.0.2: {}
 
   undici-types@7.16.0: {}
 
@@ -5058,11 +5058,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
-  vite-tsconfig-paths@6.0.3(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)):
+  vite-tsconfig-paths@6.0.3(typescript@6.0.2)(vite@7.3.1(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@5.9.3)
+      tsconfck: 3.1.6(typescript@6.0.2)
     optionalDependencies:
       vite: 7.3.1(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
     transitivePeerDependencies:

--- a/tests/unit/components/CardSelector.test.tsx
+++ b/tests/unit/components/CardSelector.test.tsx
@@ -4,6 +4,7 @@ import { NextIntlClientProvider } from 'next-intl';
 
 import { CardSelector } from '@/components/CardSelector';
 import { getAddableCards, getCharacterHiramekiCards, getCardById } from '@/lib/card';
+import { GodType } from '@/types';
 
 vi.mock('@/lib/card', () => ({
   getCharacterHiramekiCards: vi.fn(() => []),
@@ -114,7 +115,7 @@ describe('CardSelector', () => {
   beforeEach(() => {
     vi.mocked(getAddableCards).mockReturnValue([]);
     vi.mocked(getCharacterHiramekiCards).mockReturnValue([]);
-    vi.mocked(getCardById).mockReturnValue(null);
+    vi.mocked(getCardById).mockReturnValue(undefined);
   });
 
   it('restores removed cards with snapshot state intact', () => {
@@ -136,8 +137,8 @@ describe('CardSelector', () => {
               count: 1,
               selectedHiramekiLevel: 2,
               selectedHiddenHiramekiId: 'hidden_01',
-              personaEngravings: [{ id: 'umbra_attack_boost', alignment: 'dark' }],
-              godHiramekiType: 'kilken',
+      personaEngravings: [{ id: 'umbra_attack_boost', alignment: 'dark' as const }],
+              godHiramekiType: GodType.KILKEN,
               godHiramekiEffectId: 'kilken_01',
               isCopied: true,
               copiedFromCardId: 'persona_00',

--- a/tests/unit/hooks/useDeckBuilderStore.test.ts
+++ b/tests/unit/hooks/useDeckBuilderStore.test.ts
@@ -301,8 +301,8 @@ describe('useDeckBuilderStore', () => {
     const card = {
       ...getPersonaCard(),
       personaEngravings: [
-        { id: 'lux_attunement_discount', alignment: 'light' },
-        { id: 'umbra_attack_boost', alignment: 'dark' },
+        { id: 'lux_attunement_discount', alignment: 'light' as const },
+        { id: 'umbra_attack_boost', alignment: 'dark' as const },
       ],
     };
     act(() => {
@@ -449,8 +449,8 @@ describe('useDeckBuilderStore', () => {
     const card = {
       ...getPersonaCard(),
       personaEngravings: [
-        { id: 'lux_attunement_discount', alignment: 'light' },
-        { id: 'umbra_attack_boost', alignment: 'dark' },
+        { id: 'lux_attunement_discount', alignment: 'light' as const },
+        { id: 'umbra_attack_boost', alignment: 'dark' as const },
       ],
     };
     act(() => {
@@ -514,7 +514,7 @@ describe('useDeckBuilderStore', () => {
   it('convertCardでペルソナ刻印を持つカードを変換するとスナップショットに保持される', () => {
     const card = {
       ...getPersonaCard(),
-      personaEngravings: [{ id: 'umbra_attack_boost', alignment: 'dark' }],
+      personaEngravings: [{ id: 'umbra_attack_boost', alignment: 'dark' as const }],
     };
     const targetId = CHARACTERS[0].startingCards[0];
 
@@ -1062,7 +1062,7 @@ describe('useDeckBuilderStore', () => {
       const removedEntry = {
         count: 1,
         type: personaCard.type,
-        grade: personaCard.grade,
+        grade: undefined,
         selectedHiramekiLevel: 0,
         selectedHiddenHiramekiId: null,
         personaEngravings: [{ id: 'lux_attunement_discount', alignment: 'light' as const }],

--- a/tests/unit/lib/calculateFaintMemory.test.ts
+++ b/tests/unit/lib/calculateFaintMemory.test.ts
@@ -1542,7 +1542,7 @@ describe('calculateFaintMemory (追加カバレッジ)', () => {
 
     it('should add 10pt for equipment refinement', () => {
       const mockEquipment: Equipment = { id: 'weapon-1', name: 'Test Weapon', type: EquipmentType.WEAPON, rarity: 'common' };
-      baseDeck.equipment.weapon = { item: mockEquipment, refinement: true, godHammerEquipmentId: null };
+      baseDeck.equipment.weapon = { item: mockEquipment, refinement: 'refinement-1', godHammerEquipmentId: null };
 
       expect(calculateFaintMemory(baseDeck)).toBe(10);
     });
@@ -1556,7 +1556,7 @@ describe('calculateFaintMemory (追加カバレッジ)', () => {
 
     it('should add 20pt for both refinement and god hammer on same equipment', () => {
       const mockEquipment: Equipment = { id: 'weapon-1', name: 'Test Weapon', type: EquipmentType.WEAPON, rarity: 'common' };
-      baseDeck.equipment.weapon = { item: mockEquipment, refinement: true, godHammerEquipmentId: 'hammer-effect-1' };
+      baseDeck.equipment.weapon = { item: mockEquipment, refinement: 'refinement-1', godHammerEquipmentId: 'hammer-effect-1' };
 
       expect(calculateFaintMemory(baseDeck)).toBe(20);
     });
@@ -1566,24 +1566,24 @@ describe('calculateFaintMemory (追加カバレッジ)', () => {
       const mockArmor: Equipment = { id: 'armor-1', name: 'Test Armor', type: EquipmentType.ARMOR, rarity: 'common' };
       const mockPendant: Equipment = { id: 'pendant-1', name: 'Test Pendant', type: EquipmentType.PENDANT, rarity: 'common' };
 
-      baseDeck.equipment.weapon = { item: mockWeapon, refinement: true, godHammerEquipmentId: 'hammer-effect-1' };
-      baseDeck.equipment.armor = { item: mockArmor, refinement: true, godHammerEquipmentId: 'hammer-effect-2' };
-      baseDeck.equipment.pendant = { item: mockPendant, refinement: true, godHammerEquipmentId: 'hammer-effect-3' };
+      baseDeck.equipment.weapon = { item: mockWeapon, refinement: 'refinement-1', godHammerEquipmentId: 'hammer-effect-1' };
+      baseDeck.equipment.armor = { item: mockArmor, refinement: 'refinement-1', godHammerEquipmentId: 'hammer-effect-2' };
+      baseDeck.equipment.pendant = { item: mockPendant, refinement: 'refinement-1', godHammerEquipmentId: 'hammer-effect-3' };
 
       expect(calculateFaintMemory(baseDeck)).toBe(60); // 20 each * 3
     });
 
     it('should not add points if equipment is not selected', () => {
-      baseDeck.equipment.weapon = { item: null, refinement: true, godHammerEquipmentId: 'hammer-effect-1' };
-      baseDeck.equipment.armor = { item: null, refinement: true, godHammerEquipmentId: 'hammer-effect-2' };
-      baseDeck.equipment.pendant = { item: null, refinement: true, godHammerEquipmentId: 'hammer-effect-3' };
+      baseDeck.equipment.weapon = { item: null, refinement: 'refinement-1', godHammerEquipmentId: 'hammer-effect-1' };
+      baseDeck.equipment.armor = { item: null, refinement: 'refinement-1', godHammerEquipmentId: 'hammer-effect-2' };
+      baseDeck.equipment.pendant = { item: null, refinement: 'refinement-1', godHammerEquipmentId: 'hammer-effect-3' };
 
       expect(calculateFaintMemory(baseDeck)).toBe(0);
     });
 
     it('should combine equipment and card points', () => {
       const mockEquipment: Equipment = { id: 'weapon-1', name: 'Test Weapon', type: EquipmentType.WEAPON, rarity: 'common' };
-      baseDeck.equipment.weapon = { item: mockEquipment, refinement: true, godHammerEquipmentId: null };
+      baseDeck.equipment.weapon = { item: mockEquipment, refinement: 'refinement-1', godHammerEquipmentId: null };
 
       const variation: HiramekiVariation = {
         level: 0,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,8 @@
         "./*"
       ]
     },
-    "target": "ES2017"
+    "allowArbitraryExtensions": true,
+    "target": "ES2022"
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
## 概要

TypeScript を 5.9.3 から 6.0.2 にアップグレードします。

## 変更内容

- typescript: 5.9.3 -> 6.0.0 (インストールバージョン: 6.0.2)
- tsconfig.json: allowArbitraryExtensions: true 追加、target: ES2022
- app/globals.css.d.ts: CSS副作用インポート用宣言ファイル (TS2882対応)
- テストファイル3件: TS 6.0 型推論強化への対応 (GodType enum、as const、refinement型修正)

## 検証結果

- npx tsc --noEmit: エラーゼロ
- pnpm test: 245テストパス
- pnpm build: ビルド成功