### PR TITLE
fix(issue-35): separate persona card images for ATTACK and SKILL categories

### DIFF
--- a/lib/deck-utils.ts
+++ b/lib/deck-utils.ts
@@ -100,6 +100,7 @@ export function getCardInfo(
       baseDescription: description,
       baseStatuses: statuses ?? [],
       engravings: card.personaEngravings ?? [],
+      category,
       localization: localization?.persona,
     });
 

--- a/lib/persona.ts
+++ b/lib/persona.ts
@@ -1,4 +1,4 @@
-import { CardStatus, JobType, PersonaEngraving, PersonaEngravingAlignment } from "@/types";
+import { CardStatus, JobType, PersonaEngraving, PersonaEngravingAlignment, CardCategory } from "@/types";
 
 export const VALID_PERSONA_ENGRAVING_ALIGNMENTS: ReadonlySet<PersonaEngravingAlignment> = new Set(["light", "dark"]);
 
@@ -19,6 +19,7 @@ export interface PersonaCardPresentationInput {
   baseDescription: string;
   baseStatuses: CardStatus[];
   engravings?: PersonaEngraving[];
+  category?: CardCategory;
   localization?: PersonaPresentationLocalization;
 }
 
@@ -286,6 +287,16 @@ const PERSONA_IMAGE_BY_SIGNATURE: Record<string, string> = {
   "light-dark": "/images/cards/persona_of_boundary.png",
 };
 
+const PERSONA_SKILL_IMAGE_BY_SIGNATURE: Record<string, string> = {
+  none: "/images/cards/persona_skill.png",
+  light: "/images/cards/lux_persona_skill.png",
+  dark: "/images/cards/umbra_persona_skill.png",
+  "light-light": "/images/cards/persona_of_luster_skill.png",
+  "dark-dark": "/images/cards/persona_of_obsidian_skill.png",
+  "dark-light": "/images/cards/persona_of_boundary_skill.png",
+  "light-dark": "/images/cards/persona_of_boundary_skill.png",
+};
+
 const PERSONA_NAME_BY_VARIANT: Record<PersonaNameVariant, string> = {
   base: "ペルソナ",
   light: "光のペルソナ",
@@ -311,9 +322,10 @@ const getPersonaName = (engravings: PersonaEngraving[], localization?: PersonaPr
   return localization?.getName?.(variant) ?? PERSONA_NAME_BY_VARIANT[variant];
 };
 
-const getPersonaImageUrl = (engravings: PersonaEngraving[], fallback: string): string => {
+const getPersonaImageUrl = (engravings: PersonaEngraving[], fallback: string, category?: CardCategory): string => {
   const signature = engravings.length === 0 ? "none" : engravings.map((engraving) => engraving.alignment).join("-");
-  return PERSONA_IMAGE_BY_SIGNATURE[signature] ?? fallback;
+  const imageMap = category === CardCategory.SKILL ? PERSONA_SKILL_IMAGE_BY_SIGNATURE : PERSONA_IMAGE_BY_SIGNATURE;
+  return imageMap[signature] ?? fallback;
 };
 
 const getPersonaEngravingDefinition = (engraving: PersonaEngraving): PersonaEngravingDefinition | undefined =>
@@ -357,12 +369,13 @@ export function getPersonaCardPresentation({
   baseDescription,
   baseStatuses,
   engravings = [],
+  category,
   localization,
 }: PersonaCardPresentationInput): PersonaCardPresentation {
   if (engravings.length === 0) {
     return {
       name: baseName,
-      imgUrl: baseImageUrl,
+      imgUrl: getPersonaImageUrl([], baseImageUrl, category),
       cost: baseCost,
       description: baseDescription,
       statuses: baseStatuses,
@@ -392,7 +405,7 @@ export function getPersonaCardPresentation({
 
   return {
     name: getPersonaName(engravings, localization),
-    imgUrl: getPersonaImageUrl(engravings, baseImageUrl),
+    imgUrl: getPersonaImageUrl(engravings, baseImageUrl, category),
     cost,
     description: descriptions.join("\n"),
     statuses,

--- a/tests/unit/lib/persona.test.ts
+++ b/tests/unit/lib/persona.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { getPersonaCardPresentation, getPersonaNameVariant, normalizePersonaCardEngravings } from '@/lib/persona';
-import { CardStatus } from '@/types';
+import { CardStatus, CardCategory } from '@/types';
 
 describe('getPersonaCardPresentation', () => {
   it('applies a single light engraving to persona cards', () => {
@@ -125,5 +125,126 @@ describe('normalizePersonaCardEngravings', () => {
       { id: 'unknown_id_xyz', alignment: 'light' },
     ]);
     expect(result).toEqual([]);
+  });
+});
+
+describe('getPersonaCardPresentation - image selection by category', () => {
+  it('uses ATTACK image for ATTACK category persona card', () => {
+    const result = getPersonaCardPresentation({
+      baseName: 'ペルソナ',
+      baseImageUrl: '/images/cards/persona.png',
+      baseCost: 1,
+      baseDescription: 'ダメージ250%',
+      baseStatuses: [],
+      category: CardCategory.ATTACK,
+    });
+
+    expect(result.imgUrl).toBe('/images/cards/persona.png');
+  });
+
+  it('uses SKILL image for SKILL category persona card', () => {
+    const result = getPersonaCardPresentation({
+      baseName: 'ペルソナ',
+      baseImageUrl: '/images/cards/persona.png',
+      baseCost: 1,
+      baseDescription: 'ダメージ250%',
+      baseStatuses: [],
+      category: CardCategory.SKILL,
+    });
+
+    expect(result.imgUrl).toBe('/images/cards/persona_skill.png');
+  });
+
+  it('uses light ATTACK image for ATTACK with light engraving', () => {
+    const result = getPersonaCardPresentation({
+      baseName: 'ペルソナ',
+      baseImageUrl: '/images/cards/persona.png',
+      baseCost: 1,
+      baseDescription: 'ダメージ250%',
+      baseStatuses: [],
+      engravings: [{ id: 'lux_haste_discount', alignment: 'light' }],
+      category: CardCategory.ATTACK,
+    });
+
+    expect(result.imgUrl).toBe('/images/cards/lux_persona.png');
+  });
+
+  it('uses light SKILL image for SKILL with light engraving', () => {
+    const result = getPersonaCardPresentation({
+      baseName: 'ペルソナ',
+      baseImageUrl: '/images/cards/persona.png',
+      baseCost: 1,
+      baseDescription: 'ダメージ250%',
+      baseStatuses: [],
+      engravings: [{ id: 'lux_haste_discount', alignment: 'light' }],
+      category: CardCategory.SKILL,
+    });
+
+    expect(result.imgUrl).toBe('/images/cards/lux_persona_skill.png');
+  });
+
+  it('uses dark SKILL image for SKILL with dark engraving', () => {
+    const result = getPersonaCardPresentation({
+      baseName: 'ペルソナ',
+      baseImageUrl: '/images/cards/persona.png',
+      baseCost: 1,
+      baseDescription: 'ダメージ250%',
+      baseStatuses: [],
+      engravings: [{ id: 'umbra_attack_boost', alignment: 'dark' }],
+      category: CardCategory.SKILL,
+    });
+
+    expect(result.imgUrl).toBe('/images/cards/umbra_persona_skill.png');
+  });
+
+  it('uses luster ATTACK image for ATTACK with double light engraving', () => {
+    const result = getPersonaCardPresentation({
+      baseName: 'ペルソナ',
+      baseImageUrl: '/images/cards/persona.png',
+      baseCost: 1,
+      baseDescription: 'ダメージ250%',
+      baseStatuses: [],
+      engravings: [
+        { id: 'lux_haste_discount', alignment: 'light' },
+        { id: 'lux_attunement_discount', alignment: 'light' },
+      ],
+      category: CardCategory.ATTACK,
+    });
+
+    expect(result.imgUrl).toBe('/images/cards/persona_of_luster.png');
+  });
+
+  it('uses luster SKILL image for SKILL with double light engraving', () => {
+    const result = getPersonaCardPresentation({
+      baseName: 'ペルソナ',
+      baseImageUrl: '/images/cards/persona.png',
+      baseCost: 1,
+      baseDescription: 'ダメージ250%',
+      baseStatuses: [],
+      engravings: [
+        { id: 'lux_haste_discount', alignment: 'light' },
+        { id: 'lux_attunement_discount', alignment: 'light' },
+      ],
+      category: CardCategory.SKILL,
+    });
+
+    expect(result.imgUrl).toBe('/images/cards/persona_of_luster_skill.png');
+  });
+
+  it('uses boundary SKILL image for SKILL with mixed light/dark engravings', () => {
+    const result = getPersonaCardPresentation({
+      baseName: 'ペルソナ',
+      baseImageUrl: '/images/cards/persona.png',
+      baseCost: 1,
+      baseDescription: 'ダメージ250%',
+      baseStatuses: [],
+      engravings: [
+        { id: 'lux_haste_discount', alignment: 'light' },
+        { id: 'umbra_attack_boost', alignment: 'dark' },
+      ],
+      category: CardCategory.SKILL,
+    });
+
+    expect(result.imgUrl).toBe('/images/cards/persona_of_boundary_skill.png');
   });
 });


### PR DESCRIPTION
## 説明

ペルソナカードの画像をカテゴリ別に切り替える機能を実装しました。

### 変更内容

- **ATTACK カテゴリ**: 従来のペルソナカード画像を使用
- **SKILL カテゴリ**: 新しい \_skill\ 接尾辞付き画像を使用

### 実装詳細

1. \lib/persona.ts\ に \PERSONA_SKILL_IMAGE_BY_SIGNATURE\ 定数を追加
2. \getPersonaImageUrl()\ を修正し、\category === CardCategory.SKILL\ の場合はスキル画像マッピングを使用
3. \PersonaCardPresentationInput\ インタフェースに \category\ パラメータを追加
4. \lib/deck-utils.ts\ の \getCardInfo()\ を修正し、\getPersonaCardPresentation()\ 呼び出しに \category\ を渡す

### テスト

- 8個の新規ユニットテストを追加（攻撃/スキルカテゴリと各彫刻パターンの組み合わせを検証）
- ✅ 253個のユニットテストが成功
- ✅ 63個のE2Eテストが成功
- ✅ ビルド成功

### ファイル変更

- \lib/persona.ts\: 画像マッピング定数と関数ロジック修正
- \lib/deck-utils.ts\: パラメータ引き継ぎ
- \	ests/unit/lib/persona.test.ts\: テストケース追加

Fixes #35