### PR TITLE
feat(issue-36): add support for unusable card cost

### DIFF
--- a/components/CardFrame.tsx
+++ b/components/CardFrame.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 import { ReactNode, useState } from "react";
 import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
-import { Zap } from "lucide-react";
+import { Zap, Ban } from "lucide-react";
 import { CardGrade } from "@/types";
 
 // カテゴリアイコンのマッピング
@@ -92,7 +92,11 @@ export function CardFrame({
       {/* Top overlay: cost + name/category */}
       <div className="flex items-start pt-1 lg:pt-3 ml-2 sm:ml-4 lg:ml-6 xl:ml-6 gap-2 z-10 relative">
         <div className="flex flex-col items-start">
-          <div className="text-lg sm:text-2xl lg:text-4xl xl:text-5xl font-extrabold text-white underline underline-offset-4 decoration-1 text-shadow-2xl align-middle leading-none">{cost}</div>
+          {cost === "unusable" ? (
+            <Ban className="w-6 h-6 sm:w-8 sm:h-8 lg:w-12 lg:h-12 xl:w-14 xl:h-14 text-white text-shadow-2xl" strokeWidth={2.5} />
+          ) : (
+            <div className="text-lg sm:text-2xl lg:text-4xl xl:text-5xl font-extrabold text-white underline underline-offset-4 decoration-1 text-shadow-2xl align-middle leading-none">{cost}</div>
+          )}
         </div>
         <div className="min-w-0 flex-1 text-left">
           <div className={cn("text-xs sm:text-base lg:text-lg text-shadow-2xl truncate", nameColorClass)} title={displayName}>{displayName}</div>

--- a/lib/character-cards.ts
+++ b/lib/character-cards.ts
@@ -125,7 +125,7 @@ export const CHARACTER_CARDS: CznCard[] = [
     statuses: [CardStatus.UNIQUE, CardStatus.LINKED, CardStatus.RETRIEVE3],
     imgUrl: "/images/cards/heidemarie_hirameki_4.png",
     hiramekiVariations: [ // Fallback descriptions
-      { level: 0, cost: 0, description: "墓地へ移動時、極光の光1" }
+      { level: 0, cost: "unusable", description: "墓地へ移動時、極光の光1" }
     ]
   },
   // Rita's starting cards

--- a/lib/deck-utils.ts
+++ b/lib/deck-utils.ts
@@ -20,7 +20,7 @@ export function getCardInfo(
 ): {
   name: string;
   imgUrl?: string;
-  cost: number | "X";
+  cost: number | "X" | "unusable";
   description: string;
   category: CardCategory;
   statuses?: CardStatus[]; // Return raw status array for translation

--- a/lib/persona.ts
+++ b/lib/persona.ts
@@ -15,7 +15,7 @@ export interface PersonaEngravingDefinition {
 export interface PersonaCardPresentationInput {
   baseName: string;
   baseImageUrl: string;
-  baseCost: number | "X";
+  baseCost: number | "X" | "unusable";
   baseDescription: string;
   baseStatuses: CardStatus[];
   engravings?: PersonaEngraving[];
@@ -25,7 +25,7 @@ export interface PersonaCardPresentationInput {
 export interface PersonaCardPresentation {
   name: string;
   imgUrl: string;
-  cost: number | "X";
+  cost: number | "X" | "unusable";
   description: string;
   statuses: CardStatus[];
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -106,7 +106,7 @@ export enum CardStatus {
 // Hirameki variation for a card
 export interface HiramekiVariation {
   level: number; // 0 = base, 1-5 for character cards, 1-3 for other cards
-  cost: number | "X"; // "X" allows variable-cost cards defined by effect text
+  cost: number | "X" | "unusable"; // "X" allows variable-cost cards; "unusable" means cost is forbidden
   name?: string; // Optional name override for this Hirameki level
   description: string;
   // Hiramekiでカテゴリが変化する場合の上書き
@@ -117,13 +117,13 @@ export interface HiramekiVariation {
     [egoLevel: number]: {
       statuses?: CardStatus[]; // Optional status override for this Ego level
       description: string;
-      cost?: number;
+      cost?: number | "X" | "unusable";
     };
   };
   // Variation when potential is active
   potentialVariation?: {
     description: string;
-    cost?: number;
+    cost?: number | "X" | "unusable";
   };
 }
 


### PR DESCRIPTION
## Description

This PR implements support for "unusable" card cost designation, as requested in issue #36.

Some cards like Hidemariel's "極光圧縮" (Effulgent Compression) should be marked as unusable rather than having a cost of 0. This PR adds a new cost type to the system.

## Changes

### Type Definitions (`types/index.ts`)
- Extended `HiramekiVariation.cost` type to support `number | "X" | "unusable"`
- Updated `egoVariations` and `potentialVariation` cost fields to accept new type

### Card Display (`components/CardFrame.tsx`)
- Added `Ban` icon import from lucide-react
- Implemented conditional rendering: displays crossed-out circle icon for unusable costs
- Icon is responsive across all screen sizes (sm, md, lg, xl)

### Cost Logic (`lib/deck-utils.ts`)
- Updated `getCardInfo()` return type to include `"unusable"` cost type
- Existing cost modifier logic already prevents modifications to non-numeric costs

### Persona System (`lib/persona.ts`)
- Updated `PersonaCardPresentationInput` and `PersonaCardPresentation` interfaces
- Cost modifier logic correctly handles non-numeric costs

### Card Data (`lib/character-cards.ts`)
- Updated Hidemariel's "極光圧縮" card (id: `heidemarie_hirameki_4`)
- Changed cost from `0` to `"unusable"`

## Testing

- ✅ All unit tests pass
- ✅ TypeScript compilation successful
- ✅ Production build completed without errors
- ✅ No regressions detected

## Visual Impact

Cards with unusable costs now display a distinctive "Ban" icon (⊘) instead of numeric text, making the visual distinction clear to users.

Closes #36
