### PR TITLE
fix: サイトが表示されない問題を修正（React error #310）

### DIFF
--- a/components/DeckBuilder.tsx
+++ b/components/DeckBuilder.tsx
@@ -124,12 +124,12 @@ export function DeckBuilder({ shareId }: DeckBuilderProps) {
     router.push('/');
   }, [store, router]);
 
-  if (!store.deck) {
-    return <div className="min-h-screen flex items-center justify-center text-lg">Loading...</div>;
-  }
-
   const currentDeck = store.deck;
   const faintMemoryPoints = useMemo(() => calculateFaintMemory(currentDeck), [currentDeck]);
+
+  if (!currentDeck) {
+    return <div className="min-h-screen flex items-center justify-center text-lg">Loading...</div>;
+  }
 
   return (
     <div className="min-h-screen p-4 lg:p-8 bg-gray-50 dark:bg-gray-900">


### PR DESCRIPTION
## 概要

本番サイト https://czn-deck-builder.drakontia.com/ が正しく表示されない問題を修正。

## 原因

PR #64 で追加した `useMemo` が `components/DeckBuilder.tsx` の条件付きreturn（`if (!store.deck) return ...`）の**後**に配置されており、Reactのフックのルール違反が発生していた。

```
Minified React error #310: Rendered more hooks than during the previous render.
```

## 修正内容

`components/DeckBuilder.tsx` で `currentDeck` と `useMemo` の定義を条件付きreturnの**前**に移動。

```tsx
// 修正後（正しい順序）
const currentDeck = store.deck;
const faintMemoryPoints = useMemo(() => calculateFaintMemory(currentDeck), [currentDeck]);

if (!currentDeck) {
  return <div>Loading...</div>;
}
```

`calculateFaintMemory` は `Deck | null | undefined` を受け付けるため、`store.deck` が `null` の場合でも安全に動作する。

## 確認

- ✅ ユニットテスト 310件 全件通過
- ✅ `pnpm build` 成功
