### PR TITLE
perf: モーダル系コンポーネントを next/dynamic で遅延ロード

### DIFF
--- a/components/CardActionsMenu.tsx
+++ b/components/CardActionsMenu.tsx
@@ -1,10 +1,15 @@
 "use client";
+import dynamic from "next/dynamic";
 import { useTranslations } from "next-intl";
 import { CircleX, Undo2, Copy, ArrowRightLeft, Menu } from "lucide-react";
 import { DeckCard, CznCard, JobType, CardStatus } from "@/types";
-import { ConversionModal } from "./ConversionModal";
 import { Button } from "./ui/button";
 import { useCardActionsMenu } from "@/hooks/useCardActionsMenu";
+
+const ConversionModal = dynamic(
+  () => import("./ConversionModal").then((m) => ({ default: m.ConversionModal })),
+  { ssr: false }
+);
 
 interface CardActionsMenuProps {
   card: DeckCard;

--- a/components/HiramekiControls.tsx
+++ b/components/HiramekiControls.tsx
@@ -1,10 +1,28 @@
-import { useState } from "react";
+"use client";
+
+import { useState, lazy, Suspense } from "react";
+import dynamic from "next/dynamic";
 
 import { useTranslations } from "next-intl";
 import { Lightbulb, LightbulbOff, Sparkles, Zap, ZapOff } from "lucide-react";
 
 import { DeckCard, GodType, JobType, PersonaEngraving } from "@/types";
-import { ControlButton, GodHiramekiDialog, HiramekiDialog, PersonaEngravingDialog } from "./hirameki-controls";
+import { ControlButton } from "./hirameki-controls";
+
+const HiramekiDialog = dynamic(
+  () => import("./hirameki-controls/HiramekiDialog").then((m) => ({ default: m.HiramekiDialog })),
+  { ssr: false }
+);
+
+const GodHiramekiDialog = dynamic(
+  () => import("./hirameki-controls/GodHiramekiDialog").then((m) => ({ default: m.GodHiramekiDialog })),
+  { ssr: false }
+);
+
+const PersonaEngravingDialog = dynamic(
+  () => import("./hirameki-controls/PersonaEngravingDialog").then((m) => ({ default: m.PersonaEngravingDialog })),
+  { ssr: false }
+);
 
 interface HiramekiControlsProps {
   card: DeckCard;


### PR DESCRIPTION
## 概要

モーダル系コンポーネント（HiramekiDialog、GodHiramekiDialog、ConversionModal、PersonaEngravingDialog）は条件付きでしか表示されませんが、現状すべて初期バンドルに含まれています。`next/dynamic` を使った遅延ロードに変更し、初期バンドルサイズを削減して TTI を改善します。

## 対応内容

### `components/HiramekiControls.tsx`
- `HiramekiDialog`、`GodHiramekiDialog`、`PersonaEngravingDialog` を `next/dynamic` で遅延ロード
- named export に対応するため `.then((m) => ({ default: m.Component }))` パターンを使用
- `ssr: false` で クライアント側のみロード

### `components/CardActionsMenu.tsx`
- `ConversionModal` を `next/dynamic` で遅延ロード
- 同じく named export 対応、SSR 無効化

## テスト結果

✅ **全テストグリーン: 310 passed | 1 skipped (311 total)**
- 既存テストとの互換性確認済み
- HiramekiControls / CardActionsMenu を使用する他のテストも問題なし

## 期待される効果

- 初期バンドルサイズ削減（HiramekiDialog 等のコードが初期ロード時に不要）
- Time to Interactive (TTI) 改善
- Vercel React Best Practices: bundle-dynamic-imports に準拠

## 実装の特徴

- 既存コンポーネント API に変更なし（完全な後方互換性）
- SSR 時はスキップ（`ssr: false`）
- クライアント側でのみ動的に読み込まれる

Fixes: #60