### PR TITLE
ci: PlaywrightのCI設定を公式Dockerイメージ使用に変更

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -11,6 +11,8 @@ jobs:
       options: --ipc=host
     steps:
     - uses: actions/checkout@v4
+    - name: Mark workspace as safe for git
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
     - name: Setup pnpm
       uses: pnpm/action-setup@v2
       with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -6,6 +6,10 @@ jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.57.0-noble
+    env:
+      HOME: /root
     steps:
     - uses: actions/checkout@v4
     - name: Setup pnpm
@@ -19,18 +23,6 @@ jobs:
         cache: pnpm
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
-    - name: Cache Playwright browsers
-      id: playwright-cache
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/ms-playwright
-        key: playwright-${{ runner.os }}-${{ hashFiles('**/package.json') }}
-    - name: Install Playwright Browsers
-      if: steps.playwright-cache.outputs.cache-hit != 'true'
-      run: pnpm exec playwright install --with-deps
-    - name: Install Playwright OS dependencies only
-      if: steps.playwright-cache.outputs.cache-hit == 'true'
-      run: pnpm exec playwright install-deps
     - name: Run Playwright tests
       run: pnpm exec playwright test
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -7,7 +7,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.57.0-noble
+      image: mcr.microsoft.com/playwright:v1.57.0-noble-amd64
       options: --ipc=host
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,12 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.57.0-noble
-    env:
-      HOME: /root
+      options: --ipc=host
     steps:
     - uses: actions/checkout@v4
-    - name: Mark workspace as safe for git
-      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
     - name: Setup pnpm
       uses: pnpm/action-setup@v2
       with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,6 +12,8 @@ jobs:
       HOME: /root
     steps:
     - uses: actions/checkout@v4
+    - name: Mark workspace as safe for git
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
     - name: Setup pnpm
       uses: pnpm/action-setup@v2
       with:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
+    maxWorkers: 5,
     include: ['lib/**/*.test.ts', 'tests/**/*.test.ts', 'tests/**/*.test.tsx'],
     exclude: ['node_modules', 'tests/**/*.spec.ts'],
     coverage: {


### PR DESCRIPTION
## 背景

CIでPlaywrightのブラウザインストール (`pnpm exec playwright install --with-deps`) が完了しない問題が発生していた。

## 解決策

公式Dockerイメージ `mcr.microsoft.com/playwright:v1.57.0-noble` をGitHub Actionsのコンテナとして使用することで、ブラウザのインストールを不要にした。公式イメージにはChromiumが既にインストール済みのため、インストールステップを完全に削除できる。

## 変更内容

- `container: mcr.microsoft.com/playwright:v1.57.0-noble` をジョブに追加
- Dockerコンテナ内動作に必要な環境変数 `HOME: /root` を設定
- 不要になった以下の3ステップを削除:
  - `Cache Playwright browsers` (actions/cache によるキャッシュ)
  - `Install Playwright Browsers` (キャッシュミス時のインストール)
  - `Install Playwright OS dependencies only` (キャッシュヒット時の依存関係)

Fixes: #68