### PR TITLE
perf: memoize CardFrame to reduce unnecessary rerenders

### DIFF
--- a/components/CardFrame.tsx
+++ b/components/CardFrame.tsx
@@ -1,6 +1,6 @@
 "use client";
 import Image from "next/image";
-import { ReactNode, useState } from "react";
+import { memo, ReactNode, useState } from "react";
 import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
 import { Zap, Ban } from "lucide-react";
@@ -38,7 +38,7 @@ interface CardFrameProps {
   grade?: CardGrade; // Card grade for color styling
 }
 
-export function CardFrame({
+export const CardFrame = memo(function CardFrame({
   imgUrl,
   alt,
   cost,
@@ -155,4 +155,4 @@ export function CardFrame({
       )}
     </div>
   );
-}
+});

--- a/tests/unit/components/CardFrame.test.tsx
+++ b/tests/unit/components/CardFrame.test.tsx
@@ -57,6 +57,10 @@ describe('CardFrame', () => {
     lastIconImageProps = null;
   });
 
+  it('should be wrapped with React.memo', () => {
+    expect((CardFrame as unknown as { $$typeof?: symbol }).$$typeof).toBe(Symbol.for('react.memo'));
+  });
+
   it('should render card with basic props', () => {
     renderWithIntl(
       <CardFrame


### PR DESCRIPTION
## Why
`CardFrame` was re-rendering whenever parent components re-rendered, even when card props were unchanged. This issue can multiply render cost in deck and card list UIs where many cards are displayed at once.

## What changed
- Wrapped `CardFrame` with `React.memo` while keeping the existing named export.
- Added a TDD guard test to assert `CardFrame` is memoized (`$$typeof === Symbol.for('react.memo')`).
- Kept behavior and props unchanged; this is a rendering optimization only.

## Notes for reviewers
- No API or UI behavior changes are intended.
- Existing CardFrame tests remain green with the new memoization assertion.

## Validation
- `pnpm vitest run tests/unit/components/CardFrame.test.tsx`
- `pnpm build`

Fixes: #63