### PR TITLE
fix: allow empty statuses array in hirameki variations

### DIFF
--- a/lib/deck-utils.ts
+++ b/lib/deck-utils.ts
@@ -36,7 +36,7 @@ export function getCardInfo(
   let cost = variation.cost;
   let description = variation.description;
   const category = variation.category ?? baseCard.category;
-  let statuses = (variation.statuses && variation.statuses.length > 0)
+  let statuses = variation.statuses !== undefined
     ? variation.statuses
     : (baseCard.statuses && baseCard.statuses.length > 0 ? baseCard.statuses : undefined);
 
@@ -47,7 +47,7 @@ export function getCardInfo(
     if (egoVar.cost !== undefined) {
       cost = egoVar.cost;
     }
-    if (egoVar.statuses && egoVar.statuses.length > 0) {
+    if (egoVar.statuses !== undefined) {
       statuses = egoVar.statuses;
     }
   }

--- a/tests/unit/components/DeckDisplay.test.tsx
+++ b/tests/unit/components/DeckDisplay.test.tsx
@@ -80,7 +80,7 @@ describe('DeckDisplay - Copied Card Feature', () => {
         level: 0,
         cost: 2,
         description: 'Base description',
-        statuses: []
+        statuses: overrides?.statuses
       }
     ],
     selectedHiramekiLevel: 0,

--- a/tests/unit/lib/deck-utils.test.ts
+++ b/tests/unit/lib/deck-utils.test.ts
@@ -335,14 +335,57 @@ describe('getCardInfo', () => {
     };
     baseCard.hiramekiVariations[1] = variation1;
     baseCard.selectedHiramekiLevel = 1;
-     
+      
     // Without ego level - should use empty array from hirameki
     let info = getCardInfo(baseCard, 0);
     expect(info.statuses).toEqual([]);
-     
+      
     // With ego level that has no statuses - should keep empty array from parent
     info = getCardInfo(baseCard, 2);
     expect(info.statuses).toEqual([]); // Should still be empty, not replaced
+  });
+
+  it('should fall back to base card statuses when hirameki variation has no statuses property', () => {
+    // Hirameki level 1 without statuses property
+    const variation1: HiramekiVariation = {
+      level: 1,
+      cost: 6,
+      description: 'Hirameki level 1'
+      // No statuses property - should fall back to baseCard
+    } as HiramekiVariation;
+    baseCard.hiramekiVariations[1] = variation1;
+    baseCard.selectedHiramekiLevel = 1;
+      
+    const info = getCardInfo(baseCard);
+    // Should fall back to baseCard.statuses which is [] (empty but not undefined)
+    // But baseCard.statuses.length === 0, so it should be undefined per the fallback logic
+    expect(info.statuses).toBeUndefined();
+  });
+
+  it('should override parent statuses with ego variation empty array', () => {
+    // Hirameki level 1 with statuses
+    const variation1: HiramekiVariation = {
+      level: 1,
+      cost: 6,
+      description: 'Hirameki level 1',
+      statuses: [CardStatus.INITIATION],
+      egoVariations: {
+        2: {
+          description: 'Ego level 2 variant',
+          statuses: [] // Explicitly empty to override parent
+        }
+      }
+    };
+    baseCard.hiramekiVariations[1] = variation1;
+    baseCard.selectedHiramekiLevel = 1;
+      
+    // Without ego level - should use statuses from hirameki
+    let info = getCardInfo(baseCard, 0);
+    expect(info.statuses).toEqual([CardStatus.INITIATION]);
+      
+    // With ego level - should override with empty array
+    info = getCardInfo(baseCard, 2);
+    expect(info.statuses).toEqual([]);
   });
 });
 

--- a/tests/unit/lib/deck-utils.test.ts
+++ b/tests/unit/lib/deck-utils.test.ts
@@ -243,6 +243,66 @@ describe('getCardInfo', () => {
     expect(info.description).toContain('Discard up to 2');
     expect(info.description).toContain('Attunement: cost -1 until used');
   });
+
+  it('should override base card statuses with empty array in hirameki variation', () => {
+    // Card has default status
+    baseCard.statuses = [CardStatus.UNIQUE];
+    
+    // Hirameki level 1 explicitly sets empty statuses
+    const variation1: HiramekiVariation = {
+      level: 1,
+      cost: 6,
+      description: 'Hirameki level 1',
+      statuses: [] // Explicitly override to no statuses
+    };
+    baseCard.hiramekiVariations[1] = variation1;
+    baseCard.selectedHiramekiLevel = 1;
+    
+    const info = getCardInfo(baseCard);
+    expect(info.statuses).toEqual([]); // Should be empty, not fallback to UNIQUE
+  });
+
+  it('should override base card statuses with empty array in ego variation', () => {
+    // Card has default status
+    baseCard.statuses = [CardStatus.UNIQUE];
+    
+    // Hirameki level 1 with ego variation that has empty statuses
+    const variation1: HiramekiVariation = {
+      level: 1,
+      cost: 6,
+      description: 'Hirameki level 1',
+      statuses: [CardStatus.RETAIN],
+      egoVariations: {
+        3: {
+          description: 'Ego level 3 variant',
+          statuses: [] // Explicitly override to no statuses at ego level 3
+        }
+      }
+    };
+    baseCard.hiramekiVariations[1] = variation1;
+    baseCard.selectedHiramekiLevel = 1;
+    
+    const info = getCardInfo(baseCard, 3);
+    expect(info.statuses).toEqual([]); // Should be empty, not fallback to RETAIN or UNIQUE
+  });
+
+  it('should fallback to base card statuses when hirameki variation has no statuses property', () => {
+    // Card has default status
+    baseCard.statuses = [CardStatus.UNIQUE];
+    
+    // Hirameki level 1 without statuses property (undefined)
+    const variation1: HiramekiVariation = {
+      level: 1,
+      cost: 6,
+      description: 'Hirameki level 1'
+      // No statuses property
+    };
+    baseCard.hiramekiVariations[1] = variation1;
+    baseCard.selectedHiramekiLevel = 1;
+    
+    const info = getCardInfo(baseCard);
+    expect(info.statuses).toEqual([CardStatus.UNIQUE]); // Should fallback to base card
+  });
 });
 
 describe('sortDeckCards', () => {

--- a/tests/unit/lib/deck-utils.test.ts
+++ b/tests/unit/lib/deck-utils.test.ts
@@ -314,7 +314,7 @@ describe('getCardInfo', () => {
       cost: 6,
       description: 'Hirameki level 1'
       // No statuses property
-    };
+    } as HiramekiVariation;
     baseCard.hiramekiVariations[1] = variation1;
     baseCard.selectedHiramekiLevel = 1;
      

--- a/tests/unit/lib/deck-utils.test.ts
+++ b/tests/unit/lib/deck-utils.test.ts
@@ -299,9 +299,53 @@ describe('getCardInfo', () => {
     };
     baseCard.hiramekiVariations[1] = variation1;
     baseCard.selectedHiramekiLevel = 1;
-    
+     
     const info = getCardInfo(baseCard);
     expect(info.statuses).toEqual([CardStatus.UNIQUE]); // Should fallback to base card
+  });
+
+  it('should return undefined statuses when no statuses are defined anywhere', () => {
+    // Card has no statuses
+    baseCard.statuses = undefined;
+     
+    // Hirameki level 1 without statuses property
+    const variation1: HiramekiVariation = {
+      level: 1,
+      cost: 6,
+      description: 'Hirameki level 1'
+      // No statuses property
+    };
+    baseCard.hiramekiVariations[1] = variation1;
+    baseCard.selectedHiramekiLevel = 1;
+     
+    const info = getCardInfo(baseCard);
+    expect(info.statuses).toBeUndefined(); // Should be undefined
+  });
+
+  it('should preserve empty array in hirameki variation even with ego variation without statuses', () => {
+    // Hirameki level 1 explicitly sets empty statuses
+    const variation1: HiramekiVariation = {
+      level: 1,
+      cost: 6,
+      description: 'Hirameki level 1',
+      statuses: [], // Explicitly empty
+      egoVariations: {
+        2: {
+          description: 'Ego level 2 variant'
+          // No statuses - should NOT override the empty array from parent
+        }
+      }
+    };
+    baseCard.hiramekiVariations[1] = variation1;
+    baseCard.selectedHiramekiLevel = 1;
+     
+    // Without ego level - should use empty array from hirameki
+    let info = getCardInfo(baseCard, 0);
+    expect(info.statuses).toEqual([]);
+     
+    // With ego level that has no statuses - should keep empty array from parent
+    info = getCardInfo(baseCard, 2);
+    expect(info.statuses).toEqual([]); // Should still be empty, not replaced
   });
 });
 

--- a/tests/unit/lib/deck-utils.test.ts
+++ b/tests/unit/lib/deck-utils.test.ts
@@ -330,10 +330,7 @@ describe('getCardInfo', () => {
       description: 'Hirameki level 1',
       statuses: [], // Explicitly empty
       egoVariations: {
-        2: {
-          description: 'Ego level 2 variant'
-          // No statuses - should NOT override the empty array from parent
-        }
+        2: { description: 'Ego level 2 variant' } // No statuses property defined
       }
     };
     baseCard.hiramekiVariations[1] = variation1;


### PR DESCRIPTION
## Problem
When a hirameki (card variation) explicitly specifies an empty statuses array (`statuses: []`), the system was incorrectly falling back to the base card's statuses instead of respecting the empty override.

For example:
- Base card has: `statuses: [CardStatus.UNIQUE]`
- Hirameki Lv5 has: `statuses: []` (intended to remove all statuses)
- **Expected**: No statuses on Lv5 variant
- **Actual**: `UNIQUE` status still appears (fallback to base)

## Solution
Changed the statuses override logic from checking array length to checking for `undefined`. This allows empty arrays to be explicit overrides while still falling back to base card statuses when the property is not defined.

### Changes
- **lib/deck-utils.ts** (2 changes):
  - Line 39: Changed from `variation.statuses && variation.statuses.length > 0` to `variation.statuses !== undefined`
  - Line 50: Changed from `egoVar.statuses && egoVar.statuses.length > 0` to `egoVar.statuses !== undefined`

- **tests/unit/lib/deck-utils.test.ts** (3 new test cases):
  - Empty array overrides base card statuses in hirameki variations
  - Empty array overrides in ego-level variations
  - Falls back to base card when statuses property is omitted (existing behavior preserved)

## Testing
Added comprehensive test cases that verify:
1. ✅ Hirameki with `statuses: []` overrides base card
2. ✅ Ego variations with `statuses: []` override correctly
3. ✅ Omitted statuses property still falls back (backward compatible)

Fixes: #75