### PR TITLE
ヒラメキ後にUNIQUEが外れたカードをコピー可能に修正

### DIFF
--- a/components/CardActionsMenu.tsx
+++ b/components/CardActionsMenu.tsx
@@ -40,9 +40,7 @@ export function CardActionsMenu({
   } = useCardActionsMenu({ onConvertCard, deckId: card.deckId });
 
   const variation = card.hiramekiVariations[card.selectedHiramekiLevel] ?? card.hiramekiVariations[0];
-  const effectiveStatuses = (variation?.statuses && variation.statuses.length > 0)
-    ? variation.statuses
-    : card.statuses;
+  const effectiveStatuses = variation?.statuses ?? card.statuses;
   const canCopy = !card.isBasicCard && !effectiveStatuses.includes(CardStatus.UNIQUE);
 
   // 統一されたボタンスタイル定数

--- a/tests/unit/components/CardActionsMenu.test.tsx
+++ b/tests/unit/components/CardActionsMenu.test.tsx
@@ -1,0 +1,121 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { describe, expect, it, vi } from "vitest";
+
+import { CardActionsMenu } from "@/components/CardActionsMenu";
+import { CardCategory, CardStatus, CardType, DeckCard } from "@/types";
+
+vi.mock("next/dynamic", () => ({
+  default: () => () => null,
+}));
+
+const messages = {
+  actions: {
+    menu: "メニュー",
+    undo: "戻す",
+  },
+  common: {
+    delete: "削除",
+    copy: "コピー",
+    convert: "変換",
+  },
+};
+
+function createDeckCard(overrides?: Partial<DeckCard>): DeckCard {
+  return {
+    id: "shared_test",
+    deckId: "shared_test_deck_1",
+    name: "Shared Test",
+    type: CardType.SHARED,
+    category: CardCategory.ATTACK,
+    statuses: [],
+    hiramekiVariations: [
+      {
+        level: 0,
+        cost: 1,
+        description: "base",
+        statuses: [],
+      },
+      {
+        level: 1,
+        cost: 1,
+        description: "lv1",
+        statuses: [],
+      },
+    ],
+    selectedHiramekiLevel: 0,
+    godHiramekiType: null,
+    godHiramekiEffectId: null,
+    selectedHiddenHiramekiId: null,
+    isBasicCard: false,
+    ...overrides,
+  };
+}
+
+function renderMenu(card: DeckCard) {
+  render(
+    <NextIntlClientProvider locale="ja" messages={messages}>
+      <CardActionsMenu
+        card={card}
+        onRemoveCard={vi.fn()}
+        onCopyCard={vi.fn()}
+        onConvertCard={vi.fn()}
+        onUndoCard={vi.fn()}
+      />
+    </NextIntlClientProvider>
+  );
+
+  fireEvent.click(screen.getByRole("button", { name: "メニュー" }));
+}
+
+describe("CardActionsMenu", () => {
+  it("ヒラメキでUNIQUEが外れている場合はコピーできる", () => {
+    const card = createDeckCard({
+      statuses: [CardStatus.UNIQUE],
+      selectedHiramekiLevel: 1,
+      hiramekiVariations: [
+        {
+          level: 0,
+          cost: 1,
+          description: "base",
+          statuses: [CardStatus.UNIQUE],
+        },
+        {
+          level: 1,
+          cost: 1,
+          description: "lv1",
+          statuses: [],
+        },
+      ],
+    });
+
+    renderMenu(card);
+
+    expect(screen.getByRole("button", { name: "コピー" })).toBeDefined();
+  });
+
+  it("ヒラメキ後もUNIQUEがある場合はコピーできない", () => {
+    const card = createDeckCard({
+      statuses: [],
+      selectedHiramekiLevel: 1,
+      hiramekiVariations: [
+        {
+          level: 0,
+          cost: 1,
+          description: "base",
+          statuses: [],
+        },
+        {
+          level: 1,
+          cost: 1,
+          description: "lv1",
+          statuses: [CardStatus.UNIQUE],
+        },
+      ],
+    });
+
+    renderMenu(card);
+
+    expect(screen.queryByRole("button", { name: "コピー" })).toBeNull();
+  });
+});


### PR DESCRIPTION
ヒラメキ適用後のステータス判定で、`UNIQUE` が外れているのにコピー不可になる問題を解消するための修正です。Issue #77 の期待どおり、最終的なカード状態に基づいてコピー可否を判定するようにしました。

## 変更内容
- `CardActionsMenu` のコピー可否判定を修正し、ヒラメキ側 `statuses` を空配列でも正しく優先
- `statuses: []` のヒラメキ時にコピー可能であることを確認するユニットテストを追加
- ヒラメキ後も `UNIQUE` がある場合はコピー不可である回帰テストを追加

## 補足
- 変更範囲は `CardActionsMenu` とその単体テストに限定し、既存の操作ロジックへの影響を最小化しています。

Fixes: #77