### PR TITLE
fix: コストの使用禁止マーク(Ban)アイコンを数字と同サイズに調整

### DIFF
--- a/components/CardFrame.tsx
+++ b/components/CardFrame.tsx
@@ -93,7 +93,7 @@ export const CardFrame = memo(function CardFrame({
       <div className="flex items-start pt-1 lg:pt-3 ml-2 sm:ml-4 lg:ml-6 xl:ml-6 gap-2 z-10 relative">
         <div className="flex flex-col items-start">
           {cost === "unusable" ? (
-            <Ban className="w-6 h-6 sm:w-8 sm:h-8 lg:w-12 lg:h-12 xl:w-14 xl:h-14 text-white text-shadow-2xl" strokeWidth={2.5} />
+            <Ban className="w-5 h-5 sm:w-6 sm:h-6 lg:w-9 lg:h-9 xl:w-12 xl:h-12 text-white text-shadow-2xl" strokeWidth={2.5} />
           ) : (
             <div className="text-lg sm:text-2xl lg:text-4xl xl:text-5xl font-extrabold text-white underline underline-offset-4 decoration-1 text-shadow-2xl align-middle leading-none">{cost}</div>
           )}

--- a/tests/unit/components/CardFrame.test.tsx
+++ b/tests/unit/components/CardFrame.test.tsx
@@ -247,6 +247,25 @@ describe('CardFrame', () => {
     expect(image.getAttribute('src')).toBe('/images/cards/card_placeholder.png');
   });
 
+  it('should render Ban icon with size matching single-digit number when cost is unusable', () => {
+    const { container } = renderWithIntl(
+      <CardFrame
+        imgUrl="/test.jpg"
+        alt="Test Card"
+        cost="unusable"
+        name="Test Card"
+        category="Attack"
+        categoryId="attack"
+      />
+    );
+
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+    // Ban icon should be sized to match single-digit number text (w-5 sm:w-6 lg:w-9 xl:w-12)
+    expect(svg!.className.baseVal ?? svg!.getAttribute('class')).toContain('w-5');
+    expect(svg!.className.baseVal ?? svg!.getAttribute('class')).toContain('h-5');
+  });
+
   it('should render hidden and god effect texts when provided', () => {
     const messagesWithEffects = {
       ...messages,


### PR DESCRIPTION
## 概要

コスト表示の「使用禁止」マーク（`Ban` アイコン）が、数字コストの表示サイズより一回り大きく見えていた問題を修正します。

## 変更内容

`CardFrame.tsx` の `Ban` アイコンのサイズクラスを、各ブレークポイントで数字テキスト（`text-lg / text-2xl / text-4xl / text-5xl`）と同等のサイズに縮小しました。

| ブレークポイント | 修正前 | 修正後 | 数字テキストサイズ |
|---|---|---|---|
| base | `w-6 h-6` (24px) | `w-5 h-5` (20px) | `text-lg` (18px) |
| sm | `w-8 h-8` (32px) | `w-6 h-6` (24px) | `text-2xl` (24px) |
| lg | `w-12 h-12` (48px) | `w-9 h-9` (36px) | `text-4xl` (36px) |
| xl | `w-14 h-14` (56px) | `w-12 h-12` (48px) | `text-5xl` (48px) |

## テスト

TDD で実施。`cost="unusable"` 時の `Ban` アイコンに正しいサイズクラスが付くことを検証するテストを追加し、全327件のテストがパスしています。

Fixes: #73