### PR TITLE
ペルソナ刻印で同一刻印を2枠選択可能にする

### DIFF
--- a/components/hirameki-controls/PersonaEngravingDialog.tsx
+++ b/components/hirameki-controls/PersonaEngravingDialog.tsx
@@ -26,8 +26,8 @@ interface PersonaEngravingDialogProps {
 
 function PersonaEngravingSection({ title, engravings, selectedEngravings, onToggle }: { title: string; engravings: typeof PERSONA_CARD_ENGRAVINGS; selectedEngravings: PersonaEngraving[]; onToggle: (engraving: PersonaEngraving) => void; }) {
   const t = useTranslations();
-  const selectedCount = engravings.filter((definition) =>
-    selectedEngravings.some((e) => e.id === definition.id && e.alignment === definition.alignment)
+  const selectedCount = selectedEngravings.filter((engraving) =>
+    engravings.some((definition) => definition.id === engraving.id && definition.alignment === engraving.alignment)
   ).length;
 
   return (
@@ -45,7 +45,10 @@ function PersonaEngravingSection({ title, engravings, selectedEngravings, onTogg
       <AccordionContent>
         <div className="grid gap-2">
           {engravings.map((definition) => {
-            const isSelected = selectedEngravings.some((engraving) => engraving.id === definition.id && engraving.alignment === definition.alignment);
+            const selectedTimes = selectedEngravings.filter(
+              (engraving) => engraving.id === definition.id && engraving.alignment === definition.alignment
+            ).length;
+            const isSelected = selectedTimes > 0;
             return (
               <Button
                 key={definition.id}
@@ -57,6 +60,11 @@ function PersonaEngravingSection({ title, engravings, selectedEngravings, onTogg
                 <span className={`shrink-0 w-4 h-4 flex items-center justify-center rounded-full border ${isSelected ? "bg-primary border-primary text-primary-foreground" : "border-muted-foreground/40"}`}>
                   {isSelected && <Check className="w-3 h-3" />}
                 </span>
+                {selectedTimes > 1 && (
+                  <span className="inline-flex items-center justify-center rounded-full bg-primary text-primary-foreground text-[10px] font-medium w-4 h-4 shrink-0">
+                    {selectedTimes}
+                  </span>
+                )}
                 {t(`cards.personaMeta.engravings.${definition.descriptionKey}`, { defaultValue: definition.description })}
               </Button>
             );
@@ -97,7 +105,19 @@ export function PersonaEngravingDialog(props: PersonaEngravingDialogProps) {
     translateGodEffect: (effectId, fallback) => t(`godEffects.${effectId}`, { defaultValue: fallback }),
     translateHiddenEffect: (effectId, fallback) => t(`hiddenEffects.${effectId}`, { defaultValue: fallback }),
   });
-  const toggleEngraving = (engraving: PersonaEngraving) => setPendingEngravings((current) => current.some((item) => item.id === engraving.id && item.alignment === engraving.alignment) ? current.filter((item) => !(item.id === engraving.id && item.alignment === engraving.alignment)) : current.length >= 2 ? current : [...current, engraving]);
+  const toggleEngraving = (engraving: PersonaEngraving) =>
+    setPendingEngravings((current) => {
+      const sameCount = current.filter(
+        (item) => item.id === engraving.id && item.alignment === engraving.alignment
+      ).length;
+      if (sameCount >= 2) {
+        return current.filter((item) => !(item.id === engraving.id && item.alignment === engraving.alignment));
+      }
+      if (current.length >= 2) {
+        return current;
+      }
+      return [...current, engraving];
+    });
 
   const selectedDescriptions = pendingEngravings.map((engraving) => {
     const definition = PERSONA_CARD_ENGRAVINGS.find((d) => d.id === engraving.id && d.alignment === engraving.alignment);

--- a/components/hirameki-controls/PersonaEngravingDialog.tsx
+++ b/components/hirameki-controls/PersonaEngravingDialog.tsx
@@ -107,16 +107,24 @@ export function PersonaEngravingDialog(props: PersonaEngravingDialogProps) {
   });
   const toggleEngraving = (engraving: PersonaEngraving) =>
     setPendingEngravings((current) => {
-      const sameCount = current.filter(
-        (item) => item.id === engraving.id && item.alignment === engraving.alignment
-      ).length;
-      if (sameCount >= 2) {
-        return current.filter((item) => !(item.id === engraving.id && item.alignment === engraving.alignment));
+      const isSame = (item: PersonaEngraving) => item.id === engraving.id && item.alignment === engraving.alignment;
+      const sameCount = current.filter(isSame).length;
+
+      // 0 -> 1
+      if (sameCount === 0) {
+        if (current.length >= 2) {
+          return current;
+        }
+        return [...current, engraving];
       }
-      if (current.length >= 2) {
-        return current;
+
+      // 1 -> 2 (2枠を同一刻印で埋める。別刻印が入っている場合は置き換える)
+      if (sameCount === 1) {
+        return [engraving, engraving];
       }
-      return [...current, engraving];
+
+      // 2 -> 0
+      return current.filter((item) => !isSame(item));
     });
 
   const selectedDescriptions = pendingEngravings.map((engraving) => {

--- a/lib/persona.ts
+++ b/lib/persona.ts
@@ -348,12 +348,10 @@ export function normalizePersonaCardEngravings(
     if (job && definition.allowedJobs !== "all" && !definition.allowedJobs.includes(job)) {
       continue;
     }
-    if (!normalized.some((candidate) => candidate.id === engraving.id && candidate.alignment === engraving.alignment)) {
-      normalized.push({
-        id: engraving.id,
-        alignment: engraving.alignment,
-      });
-    }
+    normalized.push({
+      id: engraving.id,
+      alignment: engraving.alignment,
+    });
     if (normalized.length >= 2) {
       break;
     }

--- a/tests/e2e/persona-engraving.spec.ts
+++ b/tests/e2e/persona-engraving.spec.ts
@@ -105,6 +105,29 @@ test.describe('Persona Card Engraving', () => {
     await expect(page.getByText('光輝のペルソナ', { exact: true }).first()).toBeVisible({ timeout: 5000 });
   });
 
+  test('clicking the same engraving cycles to two slots and updates to 光輝のペルソナ', async ({ page }) => {
+    await addPersonaCard(page);
+
+    const deckCard = getDeckCardContainerByName(page, 'ペルソナ');
+    await deckCard.getByRole('button', { name: '刻印', exact: true }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    await dialog.getByRole('button', { name: '光の刻印' }).click();
+    await page.waitForTimeout(300);
+
+    const sameEngraving = dialog.getByRole('button').filter({ hasText: '感応' }).first();
+    await expect(sameEngraving).toBeVisible({ timeout: 3000 });
+    await sameEngraving.click();
+    await sameEngraving.click();
+
+    await dialog.getByRole('button', { name: '選択' }).click();
+
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('光輝のペルソナ', { exact: true }).first()).toBeVisible({ timeout: 5000 });
+  });
+
   test('non-persona season cards do not show 刻印 button', async ({ page }) => {
     await page.getByRole('button', { name: 'シーズンカード' }).click();
     const forbiddenSection = page.getByRole('heading', { name: 'シーズンカード' }).locator('..');

--- a/tests/unit/hooks/useDeckBuilderStore.test.ts
+++ b/tests/unit/hooks/useDeckBuilderStore.test.ts
@@ -332,6 +332,23 @@ describe('useDeckBuilderStore', () => {
     ]);
   });
 
+  it('setCardPersonaEngravingsで同じ刻印を2つ設定できる', () => {
+    const card = getPersonaCard();
+    act(() => {
+      useDeckBuilderStore.getState().setCharacter(CHARACTERS[0]);
+      useDeckBuilderStore.getState().addCard(card);
+      useDeckBuilderStore.getState().setCardPersonaEngravings(card.deckId, [
+        { id: 'lux_attunement_discount', alignment: 'light' },
+        { id: 'lux_attunement_discount', alignment: 'light' },
+      ]);
+    });
+    const updated = useDeckBuilderStore.getState().deck?.cards.find(c => c.deckId === card.deckId);
+    expect(updated?.personaEngravings).toEqual([
+      { id: 'lux_attunement_discount', alignment: 'light' },
+      { id: 'lux_attunement_discount', alignment: 'light' },
+    ]);
+  });
+
   it('setCardPersonaEngravingsは非ペルソナカードには適用されない', () => {
     const card = getTestCard();
     act(() => {

--- a/tests/unit/lib/persona.test.ts
+++ b/tests/unit/lib/persona.test.ts
@@ -126,6 +126,17 @@ describe('normalizePersonaCardEngravings', () => {
     ]);
     expect(result).toEqual([]);
   });
+
+  it('同じ刻印を2つ選択した場合は2件とも保持する', () => {
+    const result = normalizePersonaCardEngravings([
+      { id: 'lux_attunement_discount', alignment: 'light' },
+      { id: 'lux_attunement_discount', alignment: 'light' },
+    ]);
+    expect(result).toEqual([
+      { id: 'lux_attunement_discount', alignment: 'light' },
+      { id: 'lux_attunement_discount', alignment: 'light' },
+    ]);
+  });
 });
 
 describe('getPersonaCardPresentation - image selection by category', () => {


### PR DESCRIPTION
## 背景
ペルソナカードはゲーム仕様上、同じ刻印を2つ付与できますが、デッキビルダーでは同一刻印の重複選択ができませんでした。これにより、実ゲームに合わせたビルド再現ができない問題がありました。

## 変更内容
- ペルソナ刻印の正規化処理で、同一 `id + alignment` の重複を許可
  - ただし上限2枠は維持
- 刻印ダイアログの選択挙動を 0->1->2->0 のサイクルに変更
  - 同じ刻印を1回目クリックで1枠、2回目クリックで2枠、3回目クリックで解除
- 重複選択時のUI表示を更新
  - セクション件数とボタン表示が重複選択を反映
- テストを追加/更新
  - `persona.test.ts`: 同一刻印2件の正規化保持
  - `useDeckBuilderStore.test.ts`: 同一刻印2件の保存
  - `persona-engraving.spec.ts`: 同一刻印2回クリックで光輝のペルソナになるE2E

## 補足
- 同一刻印を2つ選択した場合、効果は2件分として適用されます。
- 既存の2枠制限と非ペルソナカードへの非適用挙動は維持しています。

Fixes: #72