### PR TITLE
fix: ペルソナカードの仕様制約を実装

### DIFF
--- a/components/CardActionsMenu.tsx
+++ b/components/CardActionsMenu.tsx
@@ -41,7 +41,10 @@ export function CardActionsMenu({
 
   const variation = card.hiramekiVariations[card.selectedHiramekiLevel] ?? card.hiramekiVariations[0];
   const effectiveStatuses = variation?.statuses ?? card.statuses;
+  const isPersonaCard = card.id.startsWith("persona_");
   const canCopy = !card.isBasicCard && !effectiveStatuses.includes(CardStatus.UNIQUE);
+  const canRemove = !isPersonaCard;
+  const canConvert = !isPersonaCard;
 
   // 統一されたボタンスタイル定数
   const actionButtonClass = "h-6 xl:h-9 w-6 xl:w-9 rounded-full";
@@ -62,17 +65,19 @@ export function CardActionsMenu({
       </Button>
       {isOpen && (
         <div className="absolute right-0 mt-1 z-20">
-          <Button
-            type="button"
-            variant="destructive"
-            size="icon"
-            className={actionButtonClass}
-            onClick={() => { onRemoveCard(card.deckId); closeMenu(); }}
-            aria-label={t("common.delete", { defaultValue: "削除" })}
-            title={t("common.delete", { defaultValue: "削除" })}
-          >
-            <CircleX className={actionIconClass} />
-          </Button>
+          {canRemove && (
+            <Button
+              type="button"
+              variant="destructive"
+              size="icon"
+              className={actionButtonClass}
+              onClick={() => { onRemoveCard(card.deckId); closeMenu(); }}
+              aria-label={t("common.delete", { defaultValue: "削除" })}
+              title={t("common.delete", { defaultValue: "削除" })}
+            >
+              <CircleX className={actionIconClass} />
+            </Button>
+          )}
           {canCopy && (
             <Button
               type="button"
@@ -86,17 +91,19 @@ export function CardActionsMenu({
               <Copy className={actionIconClass} />
             </Button>
           )}
-          <Button
-            type="button"
-            variant="outline"
-            size="icon"
-            className={actionButtonClass}
-            onClick={handleConvertClick}
-            aria-label={t("common.convert", { defaultValue: "変換" })}
-            title={t("common.convert", { defaultValue: "変換" })}
-          >
-            <ArrowRightLeft className={actionIconClass} />
-          </Button>
+          {canConvert && (
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              className={actionButtonClass}
+              onClick={handleConvertClick}
+              aria-label={t("common.convert", { defaultValue: "変換" })}
+              title={t("common.convert", { defaultValue: "変換" })}
+            >
+              <ArrowRightLeft className={actionIconClass} />
+            </Button>
+          )}
           {!card.isBasicCard && (
             <Button
               type="button"

--- a/components/CardSelector.tsx
+++ b/components/CardSelector.tsx
@@ -22,6 +22,7 @@ interface CardSelectorProps {
 
 export function CardSelector({ character, onAddCard, onRestoreCard, removedCards, convertedCards, presentHiramekiIds, searchQuery }: CardSelectorProps) {
   const t = useTranslations();
+  const isPersonaCard = (card: CznCard) => card.id.startsWith("persona_");
   const getCardNameInfo = (card: CznCard, level: number = 0) => {
     const variationName = card.hiramekiVariations[level]?.name;
     const levelKey = `cards.${card.id}.name.${level}`;
@@ -76,16 +77,25 @@ export function CardSelector({ character, onAddCard, onRestoreCard, removedCards
   );
 
   const filteredSharedCards = useMemo(
-    () => addableCards.filter(c => c.type === CardType.SHARED).filter(matchesQuery),
-    [addableCards, matchesQuery]
+    () => addableCards
+      .filter(c => c.type === CardType.SHARED)
+      .filter((card) => !(isPersonaCard(card) && hiddenHiramekiIds.has(card.id)))
+      .filter(matchesQuery),
+    [addableCards, hiddenHiramekiIds, matchesQuery]
   );
   const filteredMonsterCards = useMemo(
-    () => addableCards.filter(c => c.type === CardType.MONSTER).filter(matchesQuery),
-    [addableCards, matchesQuery]
+    () => addableCards
+      .filter(c => c.type === CardType.MONSTER)
+      .filter((card) => !(isPersonaCard(card) && hiddenHiramekiIds.has(card.id)))
+      .filter(matchesQuery),
+    [addableCards, hiddenHiramekiIds, matchesQuery]
   );
   const filteredForbiddenCards = useMemo(
-    () => addableCards.filter(c => c.type === CardType.FORBIDDEN).filter(matchesQuery),
-    [addableCards, matchesQuery]
+    () => addableCards
+      .filter(c => c.type === CardType.FORBIDDEN)
+      .filter((card) => !(isPersonaCard(card) && hiddenHiramekiIds.has(card.id)))
+      .filter(matchesQuery),
+    [addableCards, hiddenHiramekiIds, matchesQuery]
   );
 
   const getCardTypeLabel = (type: CardType) => {

--- a/components/HiramekiControls.tsx
+++ b/components/HiramekiControls.tsx
@@ -47,8 +47,8 @@ export function HiramekiControls(props: HiramekiControlsProps) {
 
   return (
     <>
-      <ControlButton active={props.card.selectedHiramekiLevel > 0 || props.card.selectedHiddenHiramekiId !== null} label={t("card.hirameki")} onClick={() => setOpenHirameki(true)} activeIcon={<Lightbulb className={actionIconClass} />} inactiveIcon={<LightbulbOff className={actionIconClass} />} />
-      <ControlButton active={Boolean(props.card.godHiramekiType)} label={t("card.godSelect")} onClick={() => setOpenGod(true)} activeIcon={<Zap className={actionIconClass} />} inactiveIcon={<ZapOff className={actionIconClass} />} />
+      {!isPersonaCard ? <ControlButton active={props.card.selectedHiramekiLevel > 0 || props.card.selectedHiddenHiramekiId !== null} label={t("card.hirameki")} onClick={() => setOpenHirameki(true)} activeIcon={<Lightbulb className={actionIconClass} />} inactiveIcon={<LightbulbOff className={actionIconClass} />} /> : null}
+      {!isPersonaCard ? <ControlButton active={Boolean(props.card.godHiramekiType)} label={t("card.godSelect")} onClick={() => setOpenGod(true)} activeIcon={<Zap className={actionIconClass} />} inactiveIcon={<ZapOff className={actionIconClass} />} /> : null}
       {isPersonaCard ? <ControlButton active={(props.card.personaEngravings?.length ?? 0) > 0} label={t("card.personaEngraving", { defaultValue: "刻印" })} onClick={() => setOpenPersona(true)} activeIcon={<Sparkles className={actionIconClass} />} inactiveIcon={<Sparkles className={actionIconClass} />} /> : null}
       <HiramekiDialog card={props.card} egoLevel={props.egoLevel} hasPotential={props.hasPotential} open={openHirameki} onOpenChange={setOpenHirameki} onUpdateHirameki={props.onUpdateHirameki} onSetHiddenHirameki={props.onSetHiddenHirameki} />
       <GodHiramekiDialog card={props.card} egoLevel={props.egoLevel} hasPotential={props.hasPotential} open={openGod} onOpenChange={setOpenGod} onSetGodHirameki={props.onSetGodHirameki} onSetGodHiramekiEffect={props.onSetGodHiramekiEffect} />

--- a/components/deck-builder/CardCatalogSection.tsx
+++ b/components/deck-builder/CardCatalogSection.tsx
@@ -24,7 +24,11 @@ interface CardCatalogSectionProps {
 }
 
 export function CardCatalogSection(props: CardCatalogSectionProps) {
-  const presentHiramekiIds = new Set(props.deck.cards.filter((card) => card.type === CardType.CHARACTER).map((card) => card.id));
+  const presentHiramekiIds = new Set(
+    props.deck.cards
+      .filter((card) => card.type === CardType.CHARACTER || card.id.startsWith("persona_"))
+      .map((card) => card.id)
+  );
 
   return (
     <Card>

--- a/hooks/useDeckBuilderStore.ts
+++ b/hooks/useDeckBuilderStore.ts
@@ -244,6 +244,9 @@ export const useDeckBuilderStore = create<DeckBuilderStore>((set) => ({
   addCard: (card) => {
     set((state) => {
       if (!state.deck) return {};
+      if (isPersonaCard(card) && state.deck.cards.some(existing => isPersonaCard(existing))) {
+        return {};
+      }
       return {
         deck: { ...state.deck, cards: [...state.deck.cards, card] },
       };
@@ -254,6 +257,7 @@ export const useDeckBuilderStore = create<DeckBuilderStore>((set) => ({
       if (!state.deck) return {};
       const cardToRemove = state.deck.cards.find((c) => c.deckId === deckId);
       if (!cardToRemove) return {};
+      if (isPersonaCard(cardToRemove)) return {};
 
       // Check integrated removal+conversion limit (max 5 total)
       const removedCount = Array.from(state.deck.removedCards.values()).reduce((sum: number, entry) => {
@@ -426,7 +430,7 @@ export const useDeckBuilderStore = create<DeckBuilderStore>((set) => ({
         deck: {
           ...state.deck,
           cards: state.deck.cards.map((card) =>
-            card.deckId === deckId ? { ...card, selectedHiramekiLevel: level } : card
+            card.deckId === deckId && !isPersonaCard(card) ? { ...card, selectedHiramekiLevel: level } : card
           ),
         },
       };
@@ -439,7 +443,7 @@ export const useDeckBuilderStore = create<DeckBuilderStore>((set) => ({
         deck: {
           ...state.deck,
           cards: state.deck.cards.map((card) =>
-            card.deckId === deckId ? { ...card, godHiramekiType: godType } : card
+            card.deckId === deckId && !isPersonaCard(card) ? { ...card, godHiramekiType: godType } : card
           ),
         },
       };
@@ -452,7 +456,7 @@ export const useDeckBuilderStore = create<DeckBuilderStore>((set) => ({
         deck: {
           ...state.deck,
           cards: state.deck.cards.map((card) =>
-            card.deckId === deckId ? { ...card, godHiramekiEffectId: effectId } : card
+            card.deckId === deckId && !isPersonaCard(card) ? { ...card, godHiramekiEffectId: effectId } : card
           ),
         },
       };
@@ -465,7 +469,7 @@ export const useDeckBuilderStore = create<DeckBuilderStore>((set) => ({
         deck: {
           ...state.deck,
           cards: state.deck.cards.map((card) =>
-            card.deckId === deckId ? { ...card, selectedHiddenHiramekiId: hiddenHiramekiId } : card
+            card.deckId === deckId && !isPersonaCard(card) ? { ...card, selectedHiddenHiramekiId: hiddenHiramekiId } : card
           ),
         },
       };
@@ -648,6 +652,7 @@ export const useDeckBuilderStore = create<DeckBuilderStore>((set) => ({
       const asExclusion = options?.asExclusion ?? false;
       const cardToConvert = state.deck.cards.find((c) => c.deckId === deckId);
       if (!cardToConvert) return {};
+      if (isPersonaCard(cardToConvert)) return {};
       const target = getCardById(targetCardId);
       if (!target && !asExclusion) return {};
 

--- a/tests/unit/components/CardActionsMenu.test.tsx
+++ b/tests/unit/components/CardActionsMenu.test.tsx
@@ -118,4 +118,16 @@ describe("CardActionsMenu", () => {
 
     expect(screen.queryByRole("button", { name: "コピー" })).toBeNull();
   });
+
+  it("ペルソナカードでは削除と変換を表示しない", () => {
+    const card = createDeckCard({
+      id: "persona_01",
+      deckId: "persona_01_deck_1",
+    });
+
+    renderMenu(card);
+
+    expect(screen.queryByRole("button", { name: "削除" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "変換" })).toBeNull();
+  });
 });

--- a/tests/unit/components/CardSelector.test.tsx
+++ b/tests/unit/components/CardSelector.test.tsx
@@ -506,4 +506,25 @@ describe('CardSelector', () => {
     expect(screen.getByText('Hirameki Card')).toBeTruthy();
     expect(screen.queryByText('Shared Card')).toBeNull();
   });
+
+  it('hides persona card from addable list when persona already exists in deck', () => {
+    vi.mocked(getAddableCards).mockReturnValue([personaCard, sharedCard] as any);
+
+    render(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <CardSelector
+          character={null}
+          onAddCard={vi.fn()}
+          onRestoreCard={vi.fn()}
+          removedCards={new Map()}
+          convertedCards={new Map()}
+          presentHiramekiIds={new Set(['persona_01'])}
+          searchQuery=""
+        />
+      </NextIntlClientProvider>
+    );
+
+    expect(screen.queryByText('Persona')).toBeNull();
+    expect(screen.getByText('Shared Card')).toBeTruthy();
+  });
 });

--- a/tests/unit/hooks/useDeckBuilderStore.test.ts
+++ b/tests/unit/hooks/useDeckBuilderStore.test.ts
@@ -127,6 +127,22 @@ describe('useDeckBuilderStore', () => {
     expect(afterLength).toBe(initialLength - 1);
   });
 
+  it('ペルソナカードはデッキに2枚以上追加できない', () => {
+    const persona1 = getPersonaCard();
+    const persona2 = { ...getPersonaCard(), deckId: 'persona_card_2' };
+
+    act(() => {
+      useDeckBuilderStore.getState().setCharacter(CHARACTERS[0]);
+      useDeckBuilderStore.getState().addCard(persona1);
+      useDeckBuilderStore.getState().addCard(persona2);
+    });
+
+    const personaCards = useDeckBuilderStore
+      .getState()
+      .deck?.cards.filter((card) => card.id.startsWith('persona_')) ?? [];
+    expect(personaCards).toHaveLength(1);
+  });
+
   it('setDeckでcharacterがidの場合に正規化されcreatedAtがDateになる', () => {
     const deck = {
       name: 'stringdeck',
@@ -273,6 +289,22 @@ describe('useDeckBuilderStore', () => {
     });
     const updated = useDeckBuilderStore.getState().deck?.cards.find(c => c.deckId === card.deckId);
     expect(updated?.godHiramekiEffectId).toBe('effect-1');
+  });
+
+  it('ペルソナカードではヒラメキと神ヒラメキを更新できない', () => {
+    const card = getPersonaCard();
+    act(() => {
+      useDeckBuilderStore.getState().setCharacter(CHARACTERS[0]);
+      useDeckBuilderStore.getState().addCard(card);
+      useDeckBuilderStore.getState().updateCardHirameki(card.deckId, 2);
+      useDeckBuilderStore.getState().setCardGodHirameki(card.deckId, GodType.KILKEN);
+      useDeckBuilderStore.getState().setCardGodHiramekiEffect(card.deckId, 'effect-1');
+    });
+
+    const updated = useDeckBuilderStore.getState().deck?.cards.find(c => c.deckId === card.deckId);
+    expect(updated?.selectedHiramekiLevel).toBe(0);
+    expect(updated?.godHiramekiType).toBeNull();
+    expect(updated?.godHiramekiEffectId).toBeNull();
   });
 
   it('setCardHiddenHiramekiでselectedHiddenHiramekiIdが更新される', () => {
@@ -508,6 +540,21 @@ describe('useDeckBuilderStore', () => {
     expect(deck.convertedCards.has(card.id)).toBe(true);
   });
 
+  it('ペルソナカードは変換できない', () => {
+    const card = getPersonaCard();
+    const targetId = CHARACTERS[0].hiramekiCards[0];
+    act(() => {
+      useDeckBuilderStore.getState().setCharacter(CHARACTERS[0]);
+      useDeckBuilderStore.getState().addCard(card);
+      useDeckBuilderStore.getState().convertCard(card.deckId, targetId);
+    });
+
+    const deck = useDeckBuilderStore.getState().deck!;
+    expect(deck.cards.some(c => c.deckId === card.deckId)).toBe(true);
+    expect(deck.cards.some(c => c.id === targetId && c.deckId !== card.deckId)).toBe(false);
+    expect(deck.convertedCards.has(card.id)).toBe(false);
+  });
+
   it('convertCardで排除として変換すると変換先カードはデッキに入らない', () => {
     const card = getTestCard();
     const targetId = CHARACTERS[0].hiramekiCards[0];
@@ -611,6 +658,19 @@ describe('useDeckBuilderStore', () => {
     }
   });
 
+  it('ペルソナカードは削除できない', () => {
+    const card = getPersonaCard();
+    act(() => {
+      useDeckBuilderStore.getState().setCharacter(CHARACTERS[0]);
+      useDeckBuilderStore.getState().addCard(card);
+      useDeckBuilderStore.getState().removeCard(card.deckId);
+    });
+
+    const deck = useDeckBuilderStore.getState().deck!;
+    expect(deck.cards.some((deckCard) => deckCard.deckId === card.deckId)).toBe(true);
+    expect(deck.removedCards.has(card.id)).toBe(false);
+  });
+
   it('removeCardで同じカードを複数回削除するとcountが増える', () => {
     const card = getTestCard();
     act(() => {
@@ -635,9 +695,8 @@ describe('useDeckBuilderStore', () => {
 
   it('restoreCardで同じカードの削除カウントは1つずつ減る', () => {
     const card = {
-      ...getPersonaCard(),
+      ...getTestCard(),
       selectedHiddenHiramekiId: 'hiddenhirameki_01',
-      personaEngravings: [{ id: 'umbra_attack_boost', alignment: 'dark' }] as Array<{ id: string; alignment: 'light' | 'dark' }>,
     };
     act(() => {
       useDeckBuilderStore.getState().setCharacter(CHARACTERS[0]);
@@ -650,7 +709,7 @@ describe('useDeckBuilderStore', () => {
       useDeckBuilderStore.getState().removeCard('persona_card_2');
       useDeckBuilderStore.getState().restoreCard({
         ...card,
-        deckId: 'persona_restore_1',
+        deckId: 'test_restore_1',
       });
     });
 
@@ -658,7 +717,6 @@ describe('useDeckBuilderStore', () => {
     expect(entry).toMatchObject({
       count: 1,
       selectedHiddenHiramekiId: 'hiddenhirameki_01',
-      personaEngravings: [{ id: 'umbra_attack_boost', alignment: 'dark' }],
     });
   });
 
@@ -1150,7 +1208,7 @@ describe('useDeckBuilderStore', () => {
   });
 
   it('restoreCardで1回だけ削除されたカードを復元するとremovedCardsから削除される', () => {
-    const card = getPersonaCard();
+    const card = getTestCard();
     act(() => {
       useDeckBuilderStore.getState().setCharacter(CHARACTERS[0]);
       useDeckBuilderStore.getState().addCard(card);
@@ -1164,7 +1222,7 @@ describe('useDeckBuilderStore', () => {
     }
 
     act(() => {
-      useDeckBuilderStore.getState().restoreCard({ ...card, deckId: 'persona_restore_new' });
+      useDeckBuilderStore.getState().restoreCard({ ...card, deckId: 'test_restore_new' });
     });
 
     expect(useDeckBuilderStore.getState().deck?.removedCards.has(card.id)).toBe(false);


### PR DESCRIPTION
ペルソナカードの挙動が仕様とずれており、複数枚追加やヒラメキ・神ヒラメキ、削除、変換が可能になっていました。デッキ編集ルールを仕様通りに固定するため、ストア層とUI層の両方で制約を実装しました。

## 変更内容
- `useDeckBuilderStore` にペルソナ用ガードを追加
  - `persona_` カードはデッキ内1枚まで
  - ペルソナに対するヒラメキ/神ヒラメキ(隠しヒラメキ含む)更新を無効化
  - ペルソナに対する削除/変換を無効化
- UI側でも禁止操作を露出しないよう調整
  - `CardCatalogSection`/`CardSelector` で、既存ペルソナがある場合は追加候補からペルソナを除外
  - `CardActionsMenu` でペルソナの削除/変換ボタンを非表示
  - `HiramekiControls` でペルソナのヒラメキ/神ヒラメキボタンを非表示（刻印は維持）
- TDDで関連ユニットテストを追加/更新
  - ストア: 1枚制限、各禁止操作の不変性を検証
  - コンポーネント: 追加候補制御とアクション表示制御を検証

## 補足
- 対象は `persona_` プレフィックスのカードに限定しています（`persona_of_loss` は対象外）。

Fixes: #82