### PR TITLE
テネブレアの基本カード情報を公開仕様に更新

### DIFF
--- a/lib/character-cards.ts
+++ b/lib/character-cards.ts
@@ -13,42 +13,36 @@ export const CHARACTER_CARDS: CznCard[] = [
   // Tenebrea's starting cards (temporary implementation)
   {
     id: "tenebrea_starting_1",
-    name: "テンポショット", // TODO: 要確認
+    name: "サウンドチェック",
     type: CardType.CHARACTER,
     category: CardCategory.ATTACK,
     statuses: [],
     isBasicCard: true,
     isStartingCard: true,
     imgUrl: "/images/cards/card_placeholder.png",
-    hiramekiVariations: [
-      { level: 0, cost: 1, description: "ダメージ100%" } // TODO: 要確認
-    ]
+    hiramekiVariations: [{ level: 0, cost: 1, description: "ダメージ100%" }]
   },
   {
     id: "tenebrea_starting_2",
-    name: "テンポショット", // TODO: 要確認
+    name: "サウンドチェック",
     type: CardType.CHARACTER,
     category: CardCategory.ATTACK,
     statuses: [],
     isBasicCard: true,
     isStartingCard: true,
     imgUrl: "/images/cards/card_placeholder.png",
-    hiramekiVariations: [
-      { level: 0, cost: 1, description: "ダメージ100%" } // TODO: 要確認
-    ]
+    hiramekiVariations: [{ level: 0, cost: 1, description: "ダメージ100%" }]
   },
   {
     id: "tenebrea_starting_3",
-    name: "ハーモニーヒール", // TODO: 要確認
+    name: "ファンサービス",
     type: CardType.CHARACTER,
     category: CardCategory.SKILL,
     statuses: [],
     isBasicCard: true,
     isStartingCard: true,
     imgUrl: "/images/cards/card_placeholder.png",
-    hiramekiVariations: [
-      { level: 0, cost: 1, description: "治癒100%" } // TODO: 要確認
-    ]
+    hiramekiVariations: [{ level: 0, cost: 1, description: "治癒100%" }]
   },
   {
     id: "tenebrea_starting_4",

--- a/messages/en/cards.json
+++ b/messages/en/cards.json
@@ -1,19 +1,19 @@
 {
   "cards": {
     "tenebrea_starting_1": {
-      "name": "Tempo Shot",
+      "name": "Sound Check",
       "descriptions": {
         "0": "Damage 100%"
       }
     },
     "tenebrea_starting_2": {
-      "name": "Tempo Shot",
+      "name": "Sound Check",
       "descriptions": {
         "0": "Damage 100%"
       }
     },
     "tenebrea_starting_3": {
-      "name": "Harmony Heal",
+      "name": "Fan Service",
       "descriptions": {
         "0": "Heal 100%"
       }

--- a/messages/ja/cards.json
+++ b/messages/ja/cards.json
@@ -1,19 +1,19 @@
 {
   "cards": {
     "tenebrea_starting_1": {
-      "name": "テンポショット",
+      "name": "サウンドチェック",
       "descriptions": {
         "0": "ダメージ100%"
       }
     },
     "tenebrea_starting_2": {
-      "name": "テンポショット",
+      "name": "サウンドチェック",
       "descriptions": {
         "0": "ダメージ100%"
       }
     },
     "tenebrea_starting_3": {
-      "name": "ハーモニーヒール",
+      "name": "ファンサービス",
       "descriptions": {
         "0": "治癒100%"
       }

--- a/messages/ko/cards.json
+++ b/messages/ko/cards.json
@@ -1,19 +1,19 @@
 {
   "cards": {
     "tenebrea_starting_1": {
-      "name": "템포 샷",
+      "name": "사운드 체크",
       "descriptions": {
         "0": "데미지 100%"
       }
     },
     "tenebrea_starting_2": {
-      "name": "템포 샷",
+      "name": "사운드 체크",
       "descriptions": {
         "0": "데미지 100%"
       }
     },
     "tenebrea_starting_3": {
-      "name": "하모니 힐",
+      "name": "팬 서비스",
       "descriptions": {
         "0": "치유 100%"
       }

--- a/messages/zh/cards.json
+++ b/messages/zh/cards.json
@@ -1,19 +1,19 @@
 {
   "cards": {
     "tenebrea_starting_1": {
-      "name": "节奏射击",
+      "name": "声音检查",
       "descriptions": {
         "0": "伤害100%"
       }
     },
     "tenebrea_starting_2": {
-      "name": "节奏射击",
+      "name": "声音检查",
       "descriptions": {
         "0": "伤害100%"
       }
     },
     "tenebrea_starting_3": {
-      "name": "和声治疗",
+      "name": "粉丝服务",
       "descriptions": {
         "0": "治愈100%"
       }

--- a/tests/unit/lib/tenebrea.test.ts
+++ b/tests/unit/lib/tenebrea.test.ts
@@ -37,16 +37,21 @@ describe("Tenebrea character", () => {
       expect(card?.isStartingCard).toBe(true);
     });
 
-    it("tenebrea_starting_1 is basic ATTACK card", () => {
-      const card = CHARACTER_CARDS.find((c) => c.id === "tenebrea_starting_1");
-      expect(card?.category).toBe(CardCategory.ATTACK);
+    it.each([
+      { id: "tenebrea_starting_1", name: "サウンドチェック", category: CardCategory.ATTACK, description: "ダメージ100%" },
+      { id: "tenebrea_starting_2", name: "サウンドチェック", category: CardCategory.ATTACK, description: "ダメージ100%" },
+      { id: "tenebrea_starting_3", name: "ファンサービス", category: CardCategory.SKILL, description: "治癒100%" },
+    ])("$id has expected basic card info", ({ id, name, category, description }) => {
+      const card = CHARACTER_CARDS.find((c) => c.id === id);
+      expect(card?.name).toBe(name);
+      expect(card?.category).toBe(category);
       expect(card?.isBasicCard).toBe(true);
-    });
-
-    it("tenebrea_starting_3 is basic SKILL card", () => {
-      const card = CHARACTER_CARDS.find((c) => c.id === "tenebrea_starting_3");
-      expect(card?.category).toBe(CardCategory.SKILL);
-      expect(card?.isBasicCard).toBe(true);
+      expect(card?.hiramekiVariations).toHaveLength(1);
+      expect(card?.hiramekiVariations[0]).toMatchObject({
+        level: 0,
+        cost: 1,
+        description,
+      });
     });
 
     it("ミュージックスタート is non-basic and has Lv5 variation", () => {


### PR DESCRIPTION
テネブレアの基本カード情報が仮実装のままだったため、公開済みの仕様に合わせてデータを更新しました。基本カードの名称・効果・コスト・ヒラメキ有無を実データに揃えることで、デッキ編集時の表示と内部定義の不一致を解消します。

## 変更内容
- TDDで `tests/unit/lib/tenebrea.test.ts` を先に更新し、基本カード3枚の期待値を明確化
- `lib/character-cards.ts` の `tenebrea_starting_1/2/3` を以下へ更新
  - 名称: サウンドチェック / サウンドチェック / ファンサービス
  - 効果: ダメージ100% / ダメージ100% / 治癒100%
  - コスト: すべて1
  - ヒラメキ: なし（Lv0のみ）
- `messages/ja|en|zh|ko/cards.json` の該当カード名を更新し、多言語表示を整合

## 補足
- 非基本カードの `tenebrea_starting_4` は今回の更新対象外です。

## 確認
- `pnpm vitest run tests/unit/lib/tenebrea.test.ts`
- `pnpm test`
- `pnpm build`

Fixes: #86