### PR TITLE
欲望カードを曖昧な記憶ポイント加算対象から除外

### DIFF
--- a/lib/calculateFaintMemory.ts
+++ b/lib/calculateFaintMemory.ts
@@ -1,5 +1,6 @@
 import { Deck, CardType, CardGrade, RemovedCardEntry, CopiedCardEntry, ConvertedCardEntry } from "@/types";
 import { getCardById } from "./card";
+import { isSeason4CardId } from "./season4";
 
 // Calculate Faint Memory points based on deck edits
 
@@ -52,7 +53,7 @@ export function calculateFaintMemory(deck: Deck | null | undefined): number {
       }
 
       // Forbidden card: +20pt (always saved)
-      if (card.type === CardType.FORBIDDEN) {
+      if (card.type === CardType.FORBIDDEN && !isSeason4CardId(card.id)) {
         points += 20;
       }
       // V2: Hirameki points for shared cards removed (shared cards no longer gain hirameki points)
@@ -86,7 +87,7 @@ export function calculateFaintMemory(deck: Deck | null | undefined): number {
         points += 20;
       } else if (cardType === CardType.MONSTER) {
         points += getMonsterCardPoints(snapshot.grade);
-      } else if (cardType === CardType.FORBIDDEN) {
+      } else if (cardType === CardType.FORBIDDEN && !isSeason4CardId(cardId)) {
         points += 20;
       }
       // V2: Hirameki points for shared cards removed (shared cards no longer gain hirameki points)

--- a/tests/unit/lib/calculateFaintMemory.test.ts
+++ b/tests/unit/lib/calculateFaintMemory.test.ts
@@ -124,6 +124,38 @@ describe('calculateFaintMemory', () => {
     expect(calculateFaintMemory(baseDeck)).toBe(20);
   });
 
+  it('should NOT add points for season4 desire cards in deck', () => {
+    const variation: HiramekiVariation = {
+      level: 0,
+      cost: 0,
+      description: ''
+    };
+
+    baseDeck.cards.push({
+      deckId: 'season4-1',
+      id: 'traitors_execution',
+      name: '反逆者の粛清',
+      type: CardType.FORBIDDEN,
+      category: CardCategory.ATTACK,
+      statuses: [],
+      selectedHiramekiLevel: 0,
+      godHiramekiType: null,
+      godHiramekiEffectId: null,
+      selectedHiddenHiramekiId: null,
+      isBasicCard: false,
+      hiramekiVariations: [variation]
+    });
+    expect(calculateFaintMemory(baseDeck)).toBe(0);
+  });
+
+  it('should NOT add forbidden snapshot points for removed season4 desire cards', () => {
+    baseDeck.removedCards = new Map([
+      ['traitors_execution', { count: 1, type: CardType.FORBIDDEN, selectedHiramekiLevel: 0 }]
+    ]);
+
+    expect(calculateFaintMemory(baseDeck)).toBe(0);
+  });
+
   it('should NOT add hirameki points for shared cards (only base 20pt)', () => {
     const variation: HiramekiVariation = {
       level: 0,


### PR DESCRIPTION
シーズン4の欲望カードはデッキに追加しても曖昧な記憶ポイントを加算しない仕様ですが、現状は禁忌カードとして一律 +20pt が加算されていました。本PRはその仕様差分を解消するための修正です。

## 変更内容
- `calculateFaintMemory` にシーズン4カード判定を導入。
- デッキ内カード計算で、`FORBIDDEN` の +20pt から欲望カードを除外。
- `removedCards` のスナップショット属性計算でも、欲望カードの禁忌 +20pt を除外。
- ユニットテストを追加し、以下を保証。
  - 欲望カードがデッキ内にある場合は 0pt。
  - 欲望カードが削除スナップショットにある場合も禁忌属性ポイントは 0pt。

## 補足
- 要件確認に基づき、今回の除外対象は「デッキ内加算」と「削除スナップショット由来」のみです。
- コピー・変換の扱いはこのPRでは変更していません。

Fixes: #104