### PR TITLE
feat: 装備刻印 lux_08・lux_09 を追加 (#106)

### DIFF
--- a/lib/equipment-engraving.ts
+++ b/lib/equipment-engraving.ts
@@ -83,6 +83,16 @@ export const EQUIPMENT_ENGRAVING_EFFECTS: EquipmentEngravingEffect[] = [
     alignment: "light",
     description: "攻撃を受けると、攻撃者に脆弱、弱体化のうち、ランダムで1個付与(各ターン1回)",
   },
+  {
+    id: "equipment_engraving_lux_08",
+    alignment: "light",
+    description: "自分のカード発動時、30%の確率で敵全体の行動カウント1増加(各ターン1回)",
+  },
+  {
+    id: "equipment_engraving_lux_09",
+    alignment: "light",
+    description: "自分の迅速カードのダメージ量25%増加",
+  },
   // 追加：闇装備刻印
   {
     id: "equipment_engraving_umbra_09",

--- a/messages/en/equipment.json
+++ b/messages/en/equipment.json
@@ -61,6 +61,8 @@
       "equipment_engraving_umbra_08": "When your card is discarded, the next attack card you use deals +100% damage (once per turn)",
       "equipment_engraving_lux_06": "At the start of turn, deal fixed damage 100% to the target with the lowest action count",
       "equipment_engraving_lux_07": "When attacked, randomly apply 1 of Weakened or Vulnerable to the attacker (once per turn)",
+      "equipment_engraving_lux_08": "When your card is activated, 30% chance to increase all enemies' action count by 1 (once per turn)",
+      "equipment_engraving_lux_09": "Increase the damage of your Swift cards by 25%",
       "equipment_engraving_umbra_09": "Lux Engraving +1",
       "equipment_engraving_umbra_10": "When your initiative card is discarded, activate (once per turn)",
       "equipment_engraving_umbra_11": "When allies discard 2 cards by ability, draw 1 Quietus card (once per combat)",
@@ -967,3 +969,4 @@
     }
   }
 }
+

--- a/messages/ja/equipment.json
+++ b/messages/ja/equipment.json
@@ -52,6 +52,8 @@
             "equipment_engraving_umbra_08": "自分のカードが破棄された場合、次に使用する攻撃カードのダメージ量+100％（各ターン1回）",
             "equipment_engraving_lux_06": "ターン開始時、行動カウントが最も低い対象に固定ダメージ100%",
             "equipment_engraving_lux_07": "攻撃を受けると、攻撃者に脆弱、弱体化のうち、ランダムで1個付与(各ターン1回)",
+            "equipment_engraving_lux_08": "自分のカード発動時、30%の確率で敵全体の行動カウント1増加(各ターン1回)",
+            "equipment_engraving_lux_09": "自分の迅速カードのダメージ量25%増加",
             "equipment_engraving_umbra_09": "光の刻印+1",
             "equipment_engraving_umbra_10": "自分の主導カードが破棄された場合、発動（各ターン1回）",
             "equipment_engraving_umbra_11": "味方が能力でカードを2枚破棄時、安息カードを1枚ドロー（各戦闘1回）",
@@ -939,3 +941,4 @@
         }
     }
 }
+

--- a/messages/ko/equipment.json
+++ b/messages/ko/equipment.json
@@ -45,6 +45,8 @@
       "equipment_engraving_umbra_08": "自分のカードが破棄された場合、次に使用する攻撃カードのダメージ量+100％（各ターン1回）",
       "equipment_engraving_lux_06": "ターン開始時、行動カウントが最も低い対象に固定ダメージ100%",
       "equipment_engraving_lux_07": "攻撃を受けると、攻撃者に脆弱、弱体化のうち、ランダムで1個付与(各ターン1回)",
+      "equipment_engraving_lux_08": "自分のカード発動時、30%の確率で敵全体の行動カウント1増加(各ターン1回)",
+      "equipment_engraving_lux_09": "自分の迅速カードのダメージ量25%増加",
       "equipment_engraving_umbra_09": "光の刻印+1",
       "equipment_engraving_umbra_10": "自分の主導カードが破棄された場合、発動（各ターン1回）",
       "equipment_engraving_umbra_11": "味方が能力でカードを2枚破棄時、安息カードを1枚ドロー（各戦闘1回）",
@@ -819,3 +821,4 @@
     }
   }
 }
+

--- a/messages/zh/equipment.json
+++ b/messages/zh/equipment.json
@@ -45,6 +45,8 @@
       "equipment_engraving_umbra_08": "自分のカードが破棄された場合、次に使用する攻撃カードのダメージ量+100％（各ターン1回）",
       "equipment_engraving_lux_06": "ターン開始時、行動カウントが最も低い対象に固定ダメージ100%",
       "equipment_engraving_lux_07": "攻撃を受けると、攻撃者に脆弱、弱体化のうち、ランダムで1個付与(各ターン1回)",
+      "equipment_engraving_lux_08": "自分のカード発動時、30%の確率で敵全体の行動カウント1増加(各ターン1回)",
+      "equipment_engraving_lux_09": "自分の迅速カードのダメージ量25%増加",
       "equipment_engraving_umbra_09": "光の刻印+1",
       "equipment_engraving_umbra_10": "自分の主導カードが破棄された場合、発動（各ターン1回）",
       "equipment_engraving_umbra_11": "味方が能力でカードを2枚破棄時、安息カードを1枚ドロー（各戦闘1回）",
@@ -819,3 +821,4 @@
     }
   }
 }
+

--- a/tests/unit/lib/equipment-engraving.test.ts
+++ b/tests/unit/lib/equipment-engraving.test.ts
@@ -4,7 +4,7 @@ import { EQUIPMENT_ENGRAVING_EFFECTS } from '@/lib/equipment-engraving';
 
 describe('equipment-engraving', () => {
   it('defines all equipment engravings', () => {
-    expect(EQUIPMENT_ENGRAVING_EFFECTS).toHaveLength(21);
+    expect(EQUIPMENT_ENGRAVING_EFFECTS).toHaveLength(23);
   });
 
   it('keeps engraving ids unique and aligned counts intact', () => {
@@ -13,7 +13,7 @@ describe('equipment-engraving', () => {
     const darkEffects = EQUIPMENT_ENGRAVING_EFFECTS.filter((effect) => effect.alignment === 'dark');
 
     expect(new Set(ids).size).toBe(ids.length);
-    expect(lightEffects).toHaveLength(7);
+    expect(lightEffects).toHaveLength(9);
     expect(darkEffects).toHaveLength(14);
   });
 });


### PR DESCRIPTION
## 概要

Issue #106 で要求された2つの装備刻印（光アライメント）を追加します。

## 追加した刻印

| ID | アライメント | 説明 |
|----|------------|------|
| `equipment_engraving_lux_08` | 光 | 自分のカード発動時、30%の確率で敵全体の行動カウント1増加(各ターン1回) |
| `equipment_engraving_lux_09` | 光 | 自分の迅速カードのダメージ量25%増加 |

## 変更ファイル

- `lib/equipment-engraving.ts` — 刻印データを2件追加
- `tests/unit/lib/equipment-engraving.test.ts` — 期待値を更新（合計21→23件、light 7→9件）
- `messages/ja/equipment.json` — 日本語テキスト追加
- `messages/en/equipment.json` — 英語翻訳追加
- `messages/zh/equipment.json` — 日本語フォールバック追加
- `messages/ko/equipment.json` — 日本語フォールバック追加

## TDD実施

1. ✅ RED: テストを更新して失敗を確認
2. ✅ GREEN: 刻印を実装してテストを通過
3. ✅ i18n: 4言語にキーを追加

Closes #106