### PR TITLE
fix: Xコストカードの神ヒラメキ表示がNaNになる不具合を修正

### DIFF
--- a/components/hirameki-controls/GodHiramekiDialog.tsx
+++ b/components/hirameki-controls/GodHiramekiDialog.tsx
@@ -26,7 +26,25 @@ interface GodHiramekiDialogProps {
   onSetGodHiramekiEffect: (deckId: string, effectId: string | null) => void;
 }
 
-function GodEffectButton({ card, effectId, cost, selected, fallback, egoLevel, hasPotential, onSelect }: { card: DeckCard; effectId: string; cost: number; selected: boolean; fallback: string; egoLevel: number; hasPotential: boolean; onSelect: () => void; }) {
+function GodEffectButton({
+  card,
+  effectId,
+  cost,
+  selected,
+  fallback,
+  egoLevel,
+  hasPotential,
+  onSelect,
+}: {
+  card: DeckCard;
+  effectId: string;
+  cost: number | "X" | "unusable";
+  selected: boolean;
+  fallback: string;
+  egoLevel: number;
+  hasPotential: boolean;
+  onSelect: () => void;
+}) {
   const t = useTranslations();
   const previewBaseCard = {
     ...card,
@@ -82,7 +100,35 @@ export function GodHiramekiDialog(props: GodHiramekiDialogProps) {
         </DialogHeader>
         <div className="flex-1 overflow-y-auto">
           <div className={previewGridClass}>
-            {GOD_HIRAMEKI_EFFECTS.filter((effect) => effect.gods === "all" || effect.gods.includes(selectedGod ?? GodType.KILKEN)).map((effect) => <GodEffectButton key={effect.id} card={props.card} effectId={effect.id} cost={Number(getCardInfo({ ...props.card, godHiramekiType: null, godHiramekiEffectId: null }, props.egoLevel, props.hasPotential).cost) + (effect.costModifier ?? 0)} selected={props.card.godHiramekiType === (selectedGod ?? GodType.KILKEN) && props.card.godHiramekiEffectId === effect.id} fallback={effect.additionalEffect} egoLevel={props.egoLevel} hasPotential={props.hasPotential} onSelect={() => { props.onSetGodHirameki(props.card.deckId, selectedGod ?? GodType.KILKEN); props.onSetGodHiramekiEffect(props.card.deckId, effect.id); props.onOpenChange(false); }} />)}
+            {GOD_HIRAMEKI_EFFECTS.filter((effect) => effect.gods === "all" || effect.gods.includes(selectedGod ?? GodType.KILKEN)).map((effect) => {
+              const previewCost = getCardInfo(
+                {
+                  ...props.card,
+                  godHiramekiType: selectedGod ?? GodType.KILKEN,
+                  godHiramekiEffectId: effect.id,
+                },
+                props.egoLevel,
+                props.hasPotential
+              ).cost;
+
+              return (
+                <GodEffectButton
+                  key={effect.id}
+                  card={props.card}
+                  effectId={effect.id}
+                  cost={previewCost}
+                  selected={props.card.godHiramekiType === (selectedGod ?? GodType.KILKEN) && props.card.godHiramekiEffectId === effect.id}
+                  fallback={effect.additionalEffect}
+                  egoLevel={props.egoLevel}
+                  hasPotential={props.hasPotential}
+                  onSelect={() => {
+                    props.onSetGodHirameki(props.card.deckId, selectedGod ?? GodType.KILKEN);
+                    props.onSetGodHiramekiEffect(props.card.deckId, effect.id);
+                    props.onOpenChange(false);
+                  }}
+                />
+              );
+            })}
           </div>
         </div>
       </DialogContent>

--- a/tests/unit/components/GodHiramekiDialog.test.tsx
+++ b/tests/unit/components/GodHiramekiDialog.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+
+import { GodHiramekiDialog } from "@/components/hirameki-controls/GodHiramekiDialog";
+import { CardCategory, CardType, DeckCard } from "@/types";
+
+vi.mock("@/components/CardFrame", () => ({
+  CardFrame: ({ cost }: { cost: number | string }) => <div data-testid="preview-cost">{String(cost)}</div>,
+}));
+
+const messages = {
+  card: {
+    godSelect: "神ヒラメキ選択",
+  },
+  god: {
+    kilken: "キルケン",
+    seclaid: "セクレド",
+    dialos: "ディアロス",
+    nihilum: "ニヒルム",
+    vitol: "ヴィトル",
+    order: "オーダー",
+  },
+  category: {
+    attack: "攻撃",
+  },
+  common: {
+    close: "閉じる",
+  },
+  godEffects: {},
+  hiddenEffects: {},
+};
+
+function createXCostCard(): DeckCard {
+  return {
+    id: "test_x_cost_card",
+    deckId: "test_x_cost_card_deck_1",
+    name: "Xコストカード",
+    type: CardType.CHARACTER,
+    category: CardCategory.ATTACK,
+    statuses: [],
+    hiramekiVariations: [
+      {
+        level: 0,
+        cost: "X",
+        description: "test",
+      },
+    ],
+    selectedHiramekiLevel: 0,
+    godHiramekiType: null,
+    godHiramekiEffectId: null,
+    selectedHiddenHiramekiId: null,
+    isBasicCard: false,
+  };
+}
+
+describe("GodHiramekiDialog", () => {
+  it("Xコストカードの神ヒラメキプレビューでNaNを表示しない", () => {
+    render(
+      <NextIntlClientProvider
+        locale="ja"
+        messages={messages}
+        onError={() => {}}
+        getMessageFallback={({ key }) => key}
+      >
+        <GodHiramekiDialog
+          card={createXCostCard()}
+          egoLevel={0}
+          hasPotential={false}
+          open={true}
+          onOpenChange={vi.fn()}
+          onSetGodHirameki={vi.fn()}
+          onSetGodHiramekiEffect={vi.fn()}
+        />
+      </NextIntlClientProvider>
+    );
+
+    expect(screen.queryAllByText("NaN")).toHaveLength(0);
+    expect(screen.getAllByTestId("preview-cost").some((node) => node.textContent === "X")).toBe(true);
+  });
+});

--- a/tests/unit/components/GodHiramekiDialog.test.tsx
+++ b/tests/unit/components/GodHiramekiDialog.test.tsx
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
 
 import { GodHiramekiDialog } from "@/components/hirameki-controls/GodHiramekiDialog";
-import { CardCategory, CardType, DeckCard } from "@/types";
+import { CardCategory, CardType, DeckCard, GodType } from "@/types";
 
 vi.mock("@/components/CardFrame", () => ({
   CardFrame: ({ cost }: { cost: number | string }) => <div data-testid="preview-cost">{String(cost)}</div>,
@@ -77,5 +77,37 @@ describe("GodHiramekiDialog", () => {
 
     expect(screen.queryAllByText("NaN")).toHaveLength(0);
     expect(screen.getAllByTestId("preview-cost").some((node) => node.textContent === "X")).toBe(true);
+  });
+
+  it("神ヒラメキ効果を選択するとコールバックを実行する", () => {
+    const onOpenChange = vi.fn();
+    const onSetGodHirameki = vi.fn();
+    const onSetGodHiramekiEffect = vi.fn();
+    const card = createXCostCard();
+
+    render(
+      <NextIntlClientProvider
+        locale="ja"
+        messages={messages}
+        onError={() => {}}
+        getMessageFallback={({ key }) => key}
+      >
+        <GodHiramekiDialog
+          card={card}
+          egoLevel={0}
+          hasPotential={false}
+          open={true}
+          onOpenChange={onOpenChange}
+          onSetGodHirameki={onSetGodHirameki}
+          onSetGodHiramekiEffect={onSetGodHiramekiEffect}
+        />
+      </NextIntlClientProvider>
+    );
+
+    fireEvent.click(screen.getAllByTestId("preview-cost")[0]);
+
+    expect(onSetGodHirameki).toHaveBeenCalledWith(card.deckId, GodType.KILKEN);
+    expect(onSetGodHiramekiEffect).toHaveBeenCalledWith(card.deckId, expect.any(String));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 });


### PR DESCRIPTION
## 背景
神ヒラメキ選択ダイアログで、コストが `X` のカードを表示するとプレビューコストが `NaN` になる問題がありました。これは issue #108 の報告内容で、期待値は `X` 表示です。

Fixes: #108

## 対応内容
- `GodHiramekiDialog` のプレビューコスト計算から `Number(...)` による強制変換を除去しました。
- 各神ヒラメキ効果ごとに、`getCardInfo` に該当 `godHiramekiType/godHiramekiEffectId` を与えてコストを算出するように変更しました。
- これにより `number | "X" | "unusable"` をそのまま扱え、`X` コストカードでも `NaN` になりません。

## テスト
- 追加: `tests/unit/components/GodHiramekiDialog.test.tsx`
  - Xコストカードの神ヒラメキプレビューで `NaN` が表示されないこと
  - プレビューに `X` が表示されること